### PR TITLE
Adding documentation for the Python API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -52,3 +52,8 @@ Utilities
 
 .. autofunction:: pynsot.util.get_result
 .. autofunction:: pynsot.util.get_result_key
+
+Dotfile
+-------
+
+.. autoclass:: pynsot.dotfile.Dotfile

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,18 +1,54 @@
 API
 ===
 
-.. module:: pynsot.client
+.. module:: pynsot
 
 This part of the documentation is for API reference
 
 Clients
 -------
 
+.. automodule:: pynsot.client
+
 .. autofunction:: get_api_client
 .. autoclass:: BaseClient
-.. autoclass:: EmailHeaderClient
-.. autoclass:: AuthTokenClient
-.. autoclass:: BaseClientAuth
-.. autoclass:: EmailHeaderAuthentication
-.. autoclass:: AuthTokenAuthentication
+   :members:
 
+.. autoclass:: EmailHeaderClient
+   :members:
+
+.. autoclass:: AuthTokenClient
+   :members:
+
+.. autoclass:: BaseClientAuth
+   :members:
+
+.. autoclass:: EmailHeaderAuthentication
+   :members:
+
+.. autoclass:: AuthTokenAuthentication
+   :members:
+
+
+API Models
+----------
+
+.. automodule:: pynsot.models
+
+.. autoclass:: Resource
+   :members:
+
+.. autoclass:: Network
+   :members:
+
+.. autoclass:: Device
+   :members:
+
+.. autoclass:: Interface
+   :members:
+
+Utilities
+---------
+
+.. autofunction:: pynsot.util.get_result
+.. autofunction:: pynsot.util.get_result_key

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -13,31 +13,34 @@ The client default is ``auth_token``, but ``auth_header`` is more flexible for
 If sticking with the defaults, you'll need to retrieve your key from
 ``/profile`` in the web interface.
 
-Client
-------
+Refer to :ref:`config_ref` for setting these in your ``pynsotrc``
 
-.. note::
-    The preferred method is to configure your pynsotrc as you wish and then use
-    ``pynsot.client.get_api_client`` for easier code re-use. Should you need
-    something more manual, proceed
+Python Client
+-------------
 
-Following will show you how to set up a client object in Python:
+Assuming your configuration is correct, the CLI interface doesn't need anything
+special to make authentication work. The following only applies to retrieving a
+client instance in Python.
 
 .. code-block:: python
 
    from pynsot.client import AuthTokenClient, EmailHeaderClient, get_api_client
 
-   # PREFERRED
+   # This is the preferred method, returning the appropriate client according
+   # to your dotfile if no arguments are supplied.
+   #
+   # Alteratively you can override options by passing url, auth_method, and
+   # other kwargs. See `help(get_api_client) for more details
    c = get_api_client()
 
-   # OR
+   # OR using the client objects directly
 
    email = 'jathan@localhost'
    secret_key = 'qONJrNpTX0_9v7H_LN1JlA0u4gdTs4rRMQklmQF9WF4='
    url = 'http://localhost:8990/api'
-   c = Client(url, email=email, secret_key=secret_key)
+   c = AuthTokenClient(url, email=email, secret_key=secret_key)
 
-   # OR
+   # Email Header Client
    domain = 'localhost'
    auth_header = 'X-NSoT-Email'
    c = EmailHeaderClient(

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -124,10 +124,10 @@ Each resource's ``list`` action supports ``-i/--id``, ``-l/--limit`` and
 * The ``-l/--limit`` option will limit the set of results to ``N`` resources.
 * The ``-o/--offset`` option will skip the first ``N`` resources.
 
+.. _set_queries:
+
 Set Queries
 ~~~~~~~~~~~
-
-.. _set_query_ref:
 
 The Device and Network resources support a ``-q/--query`` option that is a
 representation of set operations for matching attribute/value pairs.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -127,6 +127,8 @@ Each resource's ``list`` action supports ``-i/--id``, ``-l/--limit`` and
 Set Queries
 ~~~~~~~~~~~
 
+.. _set_query_ref:
+
 The Device and Network resources support a ``-q/--query`` option that is a
 representation of set operations for matching attribute/value pairs.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,21 @@ Welcome to pynsot's documentation!
 
 Pynsot is the official client library and command-line utility for the
 :abbr:`NSoT (Network Source of Truth)` IPAM.  For more information on the core
-project, please check it out `here`_.
+project, please check it out `on Github`.
 
-.. _here: https://github.com/dropbox/nsot
+|Build Status| |Documentation Status| |PyPI Status|
+
+.. _on Github: https://github.com/dropbox/nsot
+
+.. |Build Status| image:: https://img.shields.io/travis/dropbox/pynsot/master.svg?style=flat
+   :target: https://travis-ci.org/dropbox/pynsot
+   :width: 88px
+.. |Documentation Status| image:: https://readthedocs.org/projects/pynsot/badge/?version=latest&style=flat
+   :target: https://readthedocs.org/projects/pynsot/?badge=latest
+   :width: 76px
+.. |PyPI Status| image:: https://img.shields.io/pypi/v/pynsot.svg?style=flat
+   :target: https://pypi.python.org/pypi/pynsot
+   :width: 86px
 
 .. warning::
     This project is still very much in flux and likely to have

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,5 @@
-Welcome to pynsot's documentation!
-==================================
-
+Pynsot - The Network Source of Truth Client
+===========================================
 
 Pynsot is the official client library and command-line utility for the
 :abbr:`NSoT (Network Source of Truth)` IPAM.  For more information on the core

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,12 +2,12 @@ Pynsot - The Network Source of Truth Client
 ===========================================
 
 Pynsot is the official client library and command-line utility for the
-:abbr:`NSoT (Network Source of Truth)` IPAM.  For more information on the core
-project, please check it out `on Github`.
+`Network Source of Truth (NSoT)`_ IPAM.  For more information on the core
+project, please follow the link above.
 
 |Build Status| |Documentation Status| |PyPI Status|
 
-.. _on Github: https://github.com/dropbox/nsot
+.. _Network Source of Truth (NSoT): https://github.com/dropbox/nsot
 
 .. |Build Status| image:: https://img.shields.io/travis/dropbox/pynsot/master.svg?style=flat
    :target: https://travis-ci.org/dropbox/pynsot

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -55,7 +55,7 @@ Fetching Resources
 |               |                                              |
 |               | ``c.sites(1).networks('10.0.0.0/24').get()`` |
 |               |                                              |
-|               | ``c.sites(1).networks().get(limit=1)``       |
+|               | ``c.sites(1).networks.get(limit=1)``         |
 +---------------+----------------------------------------------+
 
 The details and comparisons are shown above to demystify what the client does.
@@ -255,9 +255,136 @@ return bool.
 Querying by Attribute Values
 ----------------------------
 
-TODO
++---------------+-------------------------------------------------------------+
+| HTTP Method   | GET                                                         |
++---------------+-------------------------------------------------------------+
+| HTTP Path     | ``GET /api/sites/1/networks/query/?query='set query here'`` |
++---------------+-------------------------------------------------------------+
+| Python Client | ``c.sites(1).networks.query.get(query='set query here')``   |
++---------------+-------------------------------------------------------------+
+
+Set queries are the way to filter based an attributes and their values. The
+syntax is typical set query syntax and is lightly discussed here:
+:ref:`set_query_ref`
+
+The query itself is passed as a query param to the ``/query/`` endpoint and can
+contain regular expressions by suffixing the attribute name, as shown below:
+
+.. code-block:: python
+
+    # Everything matching exactly desc == test
+    c.sites(1).networks.query.get(query='desc=test')
+    # [{u'attributes': {u'dc': u'sfo', u'desc': u'test'},
+    #   u'id': 2,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.0.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'}]
+
+    # Everything with desc matching regex test.*
+    c.sites(1).networks.query.get(query='desc_regex=test.*')
+    # [{u'attributes': {u'desc': u'testing'},
+    #   u'id': 1,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.0.0',
+    #   u'parent_id': None,
+    #   u'prefix_length': 8,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {u'dc': u'sfo', u'desc': u'test'},
+    #   u'id': 2,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.0.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {u'dc': u'chi', u'desc': u'tester'},
+    #   u'id': 4,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.2.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'}]
+
+    # Everything NOT dc == chi
+    c.sites(1).networks.query.get(query='-dc=chi')
+    # [{u'attributes': {},
+    #   u'id': 7,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'8.8.8.0',
+    #   u'parent_id': None,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {u'desc': u'testing'},
+    #   u'id': 1,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.0.0',
+    #   u'parent_id': None,
+    #   u'prefix_length': 8,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {u'dc': u'sfo', u'desc': u'test'},
+    #   u'id': 2,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.0.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {u'dc': u'sfo'},
+    #   u'id': 6,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.1.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'},
+    #  {u'attributes': {},
+    #   u'id': 5,
+    #   u'ip_version': u'4',
+    #   u'is_ip': True,
+    #   u'network_address': u'10.0.2.1',
+    #   u'parent_id': 4,
+    #   u'prefix_length': 32,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'}]
+
+    # Everything dc == chi
+    c.sites(1).networks.query.get(query='dc=chi')
+    # [{u'attributes': {u'dc': u'chi', u'desc': u'tester'},
+    #   u'id': 4,
+    #   u'ip_version': u'4',
+    #   u'is_ip': False,
+    #   u'network_address': u'10.0.2.0',
+    #   u'parent_id': 1,
+    #   u'prefix_length': 24,
+    #   u'site_id': 1,
+    #   u'state': u'allocated'}]
+
+
 
 API Abstraction Models
 ----------------------
+
+These models were created to abstract most of the API away from the user if
+they didn't want or need it. An instance can be created by providing minimal
+info such as CIDR and desired attributes or it can take raw payload from the
+API and turn it into a model instance.
+
+You can read the docstring in the :mod:`pynsot.models` module or follow along
+for examples below.
 
 TODO

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -1,0 +1,263 @@
+Python API
+==========
+
+The Python API offers flexibility when you need it and works well for extending
+applications to be NSoT-aware.
+
+In the examples below, we're going to assume the following common pre-work done
+in your code:
+
+.. code-block:: python
+
+   from pynsot.client import get_api_client
+
+   c = get_api_client()
+
+.. note:: The tables under each section reflect the ``networks`` resource
+
+   Unless otherwise stated, everything applies to other resources as well
+
+What is Slumber?
+----------------
+
+You might notice when following along that the API clients are Slumber
+instances. Slumber is a wrapper around the `requests` library to make REST much
+more pleasant to use in Python. Each attribute of the client object represents
+part of the HTTP path.
+
+More information is found `here`_, but for the purposes of pynsot you should be
+in good hands for the rest of the document.
+
+It might help to also refer to the `REST docs`_ for NSoT.
+
+.. _here: http://slumber.readthedocs.org/en/v0.6.0/tutorial.html
+
+.. _REST docs: http://nsot.readthedocs.org/en/latest/api/rest.html
+
+Fetching Resources
+------------------
+
+
++---------------+----------------------------------------------+
+| HTTP Method   | GET                                          |
++---------------+----------------------------------------------+
+| HTTP Path     | ``GET /api/sites/1/networks/``               |
+|               |                                              |
+|               | ``GET /api/sites/1/networks/1/``             |
+|               |                                              |
+|               | ``GET /api/sites/1/networks/10.0.0.0/24/``   |
+|               |                                              |
+|               | ``GET /api/sites/1/networks/?limit=1``       |
++---------------+----------------------------------------------+
+| Python Client | ``c.sites(1).networks.get()``                |
+|               |                                              |
+|               | ``c.sites(1).networks(1).get()``             |
+|               |                                              |
+|               | ``c.sites(1).networks('10.0.0.0/24').get()`` |
+|               |                                              |
+|               | ``c.sites(1).networks().get(limit=1)``       |
++---------------+----------------------------------------------+
+
+The details and comparisons are shown above to demystify what the client does.
+This is the most basic form of fetching one or many resources.
+
+Any of these calls should return either a single dictionary or a list of
+dictionaries.
+
+In the fourth example, note the HTTP query parameter. ``limit`` is used to
+restrict the number of results returned (pagination) and ``offset`` can be
+provided to begin after ``n``. In the returned payload are the suggested
+``next`` and ``previous`` page URLs.
+
+Query parameters are used for filtering on resource properties except for by
+attribute values. (Those are covered in another section)
+
+.. note::
+
+    "all" in the following context means all, irregardless of site. Sites are
+    normally used to separate conflicting sets of data so unless you intend to
+    span sites, try to use ``c.sites(ID)`` for your normal clienting
+
+.. code-block:: python
+
+   all_nets = c.networks.get()
+   all_nets_for_site1 = c.sites(1).networks.get()
+   all_hosts = c.networks.get(prefix_length=32)
+
+   all_resources = {}
+
+   for resource_name in ['networks', 'devices', 'interfaces']:
+       client = getattr(c, resource_name)
+       all_resources[resource_name] = client.get()
+
+Creating Resources
+------------------
+
++---------------+-------------------------------------+
+| HTTP Method   | POST                                |
++---------------+-------------------------------------+
+| HTTP Path     | ``POST /api/sites/1/networks/``     |
++---------------+-------------------------------------+
+| Python Client | ``c.sites(1).networks.post({...})`` |
++---------------+-------------------------------------+
+
+To create a resource, you POST the payload to the server. Each resource has
+different required fields and defaults for those that aren't. The easiest way
+to reference this information is via the CLI help, browsing ``/api/``, or
+try-except to catch the HTTP 400 and inspect ``e.response.json()``.
+
+.. code-block:: python
+
+   net = {'attributes': {}, 'network_address': '10.0.1.0', 'prefix_length': 24}
+   c.sites(1).networks.post(net)
+   # {u'attributes': {},
+   # u'id': 6,
+   # u'ip_version': u'4',
+   # u'is_ip': False,
+   # u'network_address': u'10.0.1.0',
+   # u'parent_id': 1,
+   # u'prefix_length': 24,
+   # u'site_id': 1,
+   # u'state': u'allocated'}
+
+   try:
+       net = {'network_address': '8.8.8.0', 'prefix_length': 24}
+       c.sites(1).networks.post(net)
+   except Exception, e:
+       print(e.response.json())
+       # {u'error': {u'code': 400,
+       # u'message': {u'attributes': [u'This field is required.']}},
+       # u'status': u'error'}
+
+
+Updating Resources (Replace)
+----------------------------
+
+
++---------------+---------------------------------------------------+
+| HTTP Method   | PUT                                               |
++---------------+---------------------------------------------------+
+| HTTP Path     | ``PUT /api/sites/1/networks/1/``                  |
+|               |                                                   |
+|               | ``PUT /api/sites/1/networks/10.0.0.0/24/``        |
++---------------+---------------------------------------------------+
+| Python Client | ``c.sites(1).networks(1).put({...})``             |
+|               |                                                   |
+|               | ``c.sites(1).networks('10.0.0.0/24').put({...})`` |
++---------------+---------------------------------------------------+
+
+In NSoT, a PUT/Replace action means to update properties of a resource while
+resetting to default the unspecified properties. This is typically to replace
+``attributes`` but applies to any non set-in-stone property such as
+``parent_id``, ``id``, the resource identity keys (hostname, network, etc), and
+others.
+
+A successful call will return the new payload representing the upstream
+resource.
+
+.. code-block:: python
+
+   # Fetch example resource
+   net = c.sites(1).networks('10.0.1.0/24').get()
+   # {u'attributes': {u'desc': u'test'},
+   #  u'id': 3,
+   #  u'ip_version': u'4',
+   #  u'is_ip': False,
+   #  u'network_address': u'10.0.1.0',
+   #  u'parent_id': 1,
+   #  u'prefix_length': 24,
+   #  u'site_id': 1,
+   #  u'state': u'allocated'}
+
+   net['attributes'] = {}
+   c.sites(1).networks('10.0.1.0/24').put(net)
+   # {u'attributes': {},
+   #  u'id': 3,
+   #  u'ip_version': u'4',
+   #  u'is_ip': False,
+   #  u'network_address': u'10.0.1.0',
+   #  u'parent_id': 1,
+   #  u'prefix_length': 24,
+   #  u'site_id': 1,
+   #  u'state': u'allocated'}
+
+
+Updating Resources (Partial)
+----------------------------
+
+
++---------------+-----------------------------------------------------+
+| HTTP Method   | PATCH                                               |
++---------------+-----------------------------------------------------+
+| HTTP Path     | ``PATCH /api/sites/1/networks/1/``                  |
+|               |                                                     |
+|               | ``PATCH /api/sites/1/networks/10.0.0.0/24/``        |
++---------------+-----------------------------------------------------+
+| Python Client | ``c.sites(1).networks(1).patch({...})``             |
+|               |                                                     |
+|               | ``c.sites(1).networks('10.0.0.0/24').patch({...})`` |
++---------------+-----------------------------------------------------+
+
+As opposed to PUT which can replace existing data, PATCH is "safer" in that
+regard. If you don't provide some keys in your update, they will be untouched.
+
+As with PUT and POST, a successful one should return the new payload.
+
+.. code-block:: python
+
+   net = c.sites(1).networks('10.0.1.0/24').get()
+   # {u'attributes': {u'dc': u'sfo'},
+   # u'id': 3,
+   # u'ip_version': u'4',
+   # u'is_ip': False,
+   # u'network_address': u'10.0.1.0',
+   # u'parent_id': 1,
+   # u'prefix_length': 24,
+   # u'site_id': 1,
+   # u'state': u'allocated'}
+
+   net.pop('attributes')
+   c.sites(1).networks('10.0.1.0/24').patch(net)
+   # {u'attributes': {u'dc': u'sfo'},
+   #  u'id': 3,
+   #  u'ip_version': u'4',
+   #  u'is_ip': False,
+   #  u'network_address': u'10.0.1.0',
+   #  u'parent_id': 1,
+   #  u'prefix_length': 24,
+   #  u'site_id': 1,
+   #  u'state': u'allocated'}
+
+Deleting Resources
+------------------
+
++---------------+-------------------------------------------------+
+| HTTP Method   | DELETE                                          |
++---------------+-------------------------------------------------+
+| HTTP Path     | ``DELETE /api/sites/1/networks/1/``             |
+|               |                                                 |
+|               | ``DELETE /api/sites/1/networks/10.0.0.0/24/``   |
++---------------+-------------------------------------------------+
+| Python Client | ``c.sites(1).networks(1).delete()``             |
+|               |                                                 |
+|               | ``c.sites(1).networks('10.0.0.0/24').delete()`` |
++---------------+-------------------------------------------------+
+
+This one should be straight forward and there is no payload to deal with. Will
+return bool.
+
+
+.. code-block:: python
+
+   c.sites(1).networks('10.0.1.0/24').delete()
+   # True
+
+Querying by Attribute Values
+----------------------------
+
+TODO
+
+API Abstraction Models
+----------------------
+
+TODO

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -25,12 +25,13 @@ instances. Slumber is a wrapper around the `requests` library to make REST much
 more pleasant to use in Python. Each attribute of the client object represents
 part of the HTTP path.
 
-More information is found `here`_, but for the purposes of pynsot you should be
-in good hands for the rest of the document.
+For the purpose of pynsot you should be in good hands for the rest of this
+document, but for more information on Slumber, see the
+`official Slumber documentation`_
 
 It might help to also refer to the `REST docs`_ for NSoT.
 
-.. _here: http://slumber.readthedocs.org/en/v0.6.0/tutorial.html
+.. _official Slumber documentation: http://slumber.readthedocs.org/en/v0.6.0/tutorial.html
 
 .. _REST docs: http://nsot.readthedocs.org/en/latest/api/rest.html
 
@@ -106,6 +107,9 @@ different required fields and defaults for those that aren't. The easiest way
 to reference this information is via the CLI help, browsing ``/api/``, or
 try-except to catch the HTTP 400 and inspect ``e.response.json()``.
 
+NSoT also has BULK operations. The only difference is that the payload is an
+array of resources.
+
 .. code-block:: python
 
    net = {'attributes': {}, 'network_address': '10.0.1.0', 'prefix_length': 24}
@@ -155,6 +159,8 @@ others.
 A successful call will return the new payload representing the upstream
 resource.
 
+Like Creating, PUT also supports BULK operations.
+
 .. code-block:: python
 
    # Fetch example resource
@@ -202,6 +208,8 @@ As opposed to PUT which can replace existing data, PATCH is "safer" in that
 regard. If you don't provide some keys in your update, they will be untouched.
 
 As with PUT and POST, a successful one should return the new payload.
+
+Like Creating, PATCH also supports BULK operations.
 
 .. code-block:: python
 

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -15,7 +15,7 @@ in your code:
 
 .. note:: The tables under each section reflect the ``networks`` resource
 
-   Unless otherwise stated, everything applies to other resources as well
+   Unless otherwise stated, everything applies to other resources as well.
 
 What is Slumber?
 ----------------
@@ -27,7 +27,7 @@ part of the HTTP path.
 
 For the purpose of pynsot you should be in good hands for the rest of this
 document, but for more information on Slumber, see the
-`official Slumber documentation`_
+`official Slumber documentation`_.
 
 It might help to also refer to the `REST docs`_ for NSoT.
 
@@ -75,7 +75,7 @@ attribute values. (Those are covered in another section)
 
 .. note::
 
-    "all" in the following context means all, irregardless of site. Sites are
+    "all" in the following context means all, regardless of site. Sites are
     normally used to separate conflicting sets of data so unless you intend to
     span sites, try to use ``c.sites(ID)`` for your normal clienting
 
@@ -127,7 +127,7 @@ array of resources.
    try:
        net = {'network_address': '8.8.8.0', 'prefix_length': 24}
        c.sites(1).networks.post(net)
-   except Exception, e:
+   except Exception as e:
        print(e.response.json())
        # {u'error': {u'code': 400,
        # u'message': {u'attributes': [u'This field is required.']}},
@@ -272,8 +272,8 @@ Querying by Attribute Values
 +---------------+-------------------------------------------------------------+
 
 Set queries are the way to filter based an attributes and their values. The
-syntax is typical set query syntax and is lightly discussed here:
-:ref:`set_query_ref`
+syntax is typical set query syntax and is lightly discussed in
+:ref:`set_queries`.
 
 The query itself is passed as a query param to the ``/query/`` endpoint and can
 contain regular expressions by suffixing the attribute name, as shown below:
@@ -392,7 +392,10 @@ they didn't want or need it. An instance can be created by providing minimal
 info such as CIDR and desired attributes or it can take raw payload from the
 API and turn it into a model instance.
 
-You can read the docstring in the :mod:`pynsot.models` module or follow along
-for examples below.
+You can read the docstring in the :mod:`pynsot.models` module or follow the
+links below for usage examples. We think it's a pretty solid way to do most
+basic interaction.
 
-TODO
+* :class:`pynsot.models.Network`
+* :class:`pynsot.models.Device`
+* :class:`pynsot.models.Interface`

--- a/pynsot/models.py
+++ b/pynsot/models.py
@@ -10,8 +10,6 @@ etc).
 Example
 -------
 
-As always, refer to official docs vs. the docstring but here is an example
-
 >>> from pynsot.models import Network, Device, Interface
 >>> from pynsot.client import get_api_client
 >>> client = get_api_client()

--- a/pynsot/models.py
+++ b/pynsot/models.py
@@ -16,13 +16,13 @@ As always, refer to official docs vs. the docstring but here is an example
 >>> from pynsot.client import get_api_client
 >>> client = get_api_client()
 >>> net = Network(raw=client.networks.get()[-1])
-
-# Or also...
-# >>> net = Network(client=client, site_id=1, cidr='8.8.8.0/24')
-
+>>>
+>>> # Or also...
+>>> # >>> net = Network(client=client, site_id=1, cidr='8.8.8.0/24')
+>>>
 >>> net.exists()
 >>> True
-
+>>>
 >>> net.existing_resource()
 {u'attributes': {},
  u'id': 81,
@@ -33,29 +33,29 @@ As always, refer to official docs vs. the docstring but here is an example
  u'prefix_length': 24,
  u'site_id': 1,
  u'state': u'allocated'}
-
+>>>
 >>> net.purge()
 True
-
+>>>
 >>> net.exists()
 False
-
+>>>
 >>> net.ensure()
 True
-
+>>>
 >>> net.exists()
 True
-
+>>>
 >>> net['site_id']
 2
-
+>>>
 >>> net['site_id'] = 4
-
+>>>
 >>> net.exists()
 False
-
+>>>
 >>> net['site_id'] = 2
-
+>>>
 >>> net.exists()
 True
 '''
@@ -70,41 +70,42 @@ from pynsot.client import get_api_client
 
 
 class Resource(collections.MutableMapping):
-    '''Base Resource
+    '''Base API Abstraction Models Class
 
-    This class represents a model for subclassing NSoT resources, including
-    methods to represent itself and upload to an NSoT server.
+    Instances of an API abstraction model represent a single NSoT resource and
+    provide methods for managing the state of it upstream. They can be
+    instantiated by the raw returned object from NSoT API or more simply by a
+    few descriptive kwargs.
 
-    Instead of overloading __init__, this base class accepts **kwargs and
-    passes them to self.postinit(**kwargs). Overload postinit for setting
-    resource specific parameters and setup. Note: This does NOT execute when
-    `raw` is provided
+    Resource is a subclass of :class:``collections.MutableMapping`` which makes
+    it act as a dictionary would. The mapping represents the payload that would
+    be accepted by NSoT and can be manipulated as desired like a normal dict.
 
-    __getitem__ and __iter__ are set so you can render what the NSoT payload
-    will look like by doing dict(obj) and fetch individual keys like a
-    dictionary with obj['attributes']
+    Subclassing:
+        Subclasses must adhere to a simple contract:
+            * Overload the abstractmethods and abstractproperties this class
+              uses
+            * If custom arguments are needed, overload ``self.postinit``.
+              Just make sure to call ``self.init_payload()`` at the end. All
+              kwargs that aren't handled by ``self.__init__`` are passed here
 
-    Attributes:
-        identifier (str)
-        resource (pynsot.vendor.slumber.Resource)
-        resource_name (str)
-        logger (logging.Logger)
-        payload (dict): This represents the exact payload sent to NSoT server
-        errors (list): Collection of any errors to happen during operations
-        last_error: The last error to happen
+    :param site_id: Site ID this reseource belongs to. Required unless ``raw``
+        is supplied.
+    :type site_id: int
+    :param attributes: Attributes to add to resource. If supplying ``raw``, add
+        these after the instantiation like:
 
-    Options:
-        site_id (int): (kwarg) Site ID for operations
-            Required unless `raw['site']`. If both provided, raw takes
-            precedence.
-        attributes (dict): (kwarg) Attributes to add to resource
-        client (pynsot.client.BaseClient): (kwarg) pynsot client
-            If client is not provided, `get_api_client` will be lazily loaded
-            on first API interaction. If you're dealing with many resource
-            objects that will talk to API, it'd be `n` less function calls to
-            pass in this parameter
-        raw (dict): (kwarg) Use this to pass in raw NSoT resource
-            Useful for instantiating objects as they return from API.
+            >>> obj = Device(raw=RAW_API_DICT)
+            >>> obj['attributes'] = {}
+
+    :type attributes: dict
+    :param client: Pynsot client for API interactions. Will be lazily loaded if
+        not provided, but might be cheaper to supply it up front.
+    :type client: pynsot.client.BaseClient
+    :param raw: Raw NSoT resource object. What would be returned from a GET,
+        POST, PUT, or PATCH operation for a single resource. Gets mapped
+        directly to payload
+    :type raw: dict
     '''
 
     __metaclass__ = ABCMeta
@@ -137,7 +138,7 @@ class Resource(collections.MutableMapping):
         elif site_id:
             pass  # Already set
         else:
-            raise TypeError('Resource requires site_id via param or `raw` key')
+            raise TypeError('Resource requires site_id via param or ``raw`` key')
 
         self._site_id = site_id
         self.client = client
@@ -158,14 +159,18 @@ class Resource(collections.MutableMapping):
     def postinit(self, **kwargs):
         '''Overloadable method for post __init__
 
-        This method is called at the very end of __init__ unless `raw` is
-        given. Use-case here is that each resource type needs varying
-        information to compile itself and overloading __init__ + calling
-        `super()` is no fun.
+        Use this for things that need to happen post-init, including
+        subclass-specific argument handling.
 
-        Options:
-            kwargs (dict): All unhandled kwargs from __init__ are passed here.
+        This method is called at the very end of __init__ unless ``raw`` is
+        given.
+
+        :params kwargs: All unhandled kwargs from __init__ are passed here
+        :type kwargs: dict
         '''
+        # If not being overloaded by subclass, still need to call this required
+        # method if ``raw`` isn't provided
+        self.init_payload()
         pass
 
     def ensure_client(self, **kwargs):
@@ -173,6 +178,9 @@ class Resource(collections.MutableMapping):
 
         Client may be passed during __init__ as a kwarg, but call this before
         doing any client work to ensure
+
+        :param kwargs: These will be passed to get_api_client.
+        :type kwargs: dict
         '''
         if self.client:
             return
@@ -186,8 +194,7 @@ class Resource(collections.MutableMapping):
         Used in log messages and magic methods for comparison. Examples here
         would be CIDR, hostname, etc
 
-        Returns:
-            str
+        :rtype: str
         '''
         pass
 
@@ -195,13 +202,7 @@ class Resource(collections.MutableMapping):
     def resource(self):
         '''Pynsot client for resource type
 
-        For example using a network type:
-
-            client.networks
-            /api/networks/ equivalent
-
-        Returns:
-            pynsot.client.BaseClient
+        :rtype: pynsot.client.BaseClient
         '''
         self.ensure_client()
         return getattr(self.client, self.resource_name)
@@ -212,17 +213,14 @@ class Resource(collections.MutableMapping):
 
         Must be plural
 
-        Returns:
-            str
+        :rtype: str
         '''
         pass
 
     @abstractmethod
     def init_payload(self):
-        '''Initializes the _payload dictionary using resource specific data
-
-        This must be called in a subclass' postinit to get a populated
-        `self.payload` when `raw` isn't provided.
+        '''
+        Initializes the payload dictionary using resource specific data
         '''
         pass
 
@@ -230,8 +228,8 @@ class Resource(collections.MutableMapping):
     def payload(self):
         '''Represents exact payload sent to NSoT server
 
-        Returns:
-            _payload (dict)
+        :returns: _payload
+        :rtype: dict
         '''
         return self._payload
 
@@ -276,10 +274,13 @@ class Resource(collections.MutableMapping):
         return str(self.identifier)
 
     def __eq__(self, other):
-        '''Using `identifier` and `site_id`, compare to another resource'''
-        x = '%s:%s' % (self.identifier, self._site_id)
-        y = '%s:%s' % (other.identifier, other._site_id)
-        return x == y
+        '''Using ``identifier`` and ``site_id``, compare to another resource'''
+        try:
+            x = '%s:%s' % (self.identifier, self._site_id)
+            y = '%s:%s' % (other.identifier, other._site_id)
+            return x == y
+        except:
+            raise TypeError('Other object is not a Resource type')
 
     def log_error(self, error):
         '''Log and append errors to object
@@ -310,10 +311,9 @@ class Resource(collections.MutableMapping):
 
         If nothing exists, empty dict is returned. The result of this is cached
         in a property (_existing_resource) for cheaper re-checks. This can be
-        cleared via `.clear_cache()`
+        cleared via ``.clear_cache()``
 
-        Returns:
-            dict
+        :rtype: dict
         '''
         self.ensure_client()
         if self._existing_resource:
@@ -355,7 +355,7 @@ class Resource(collections.MutableMapping):
         '''Clears state of certain properties
 
         This is ideally done during a write operation against the API, such as
-        `.purge()` or `.ensure()`. Helps prevent representing out-of-date
+        ``.purge()`` or ``.ensure()``. Helps prevent representing out-of-date
         information
         '''
         self._existing_resource = {}
@@ -363,8 +363,7 @@ class Resource(collections.MutableMapping):
     def exists(self):
         '''Does the current resource exist?
 
-        Returns:
-            bool
+        :rtype: bool
         '''
         return bool(self.existing_resource())
 
@@ -372,7 +371,7 @@ class Resource(collections.MutableMapping):
         '''Ensure object in current state exists in NSoT
 
         By site, make sure resource exists. True if it is or was able to get to
-        the desired state, False if not and logged in `last_error`.
+        the desired state, False if not and logged in ``last_error``.
 
         Having this operation be done individually for each resource
         has some pros and cons. Generally as long as the amount of items
@@ -383,6 +382,8 @@ class Resource(collections.MutableMapping):
         so it requires more handling.
 
         Cache is cleared first thing and before return.
+
+        :rtype: bool
         '''
         self.clear_cache()
         to_ensure = dict(self)
@@ -411,9 +412,11 @@ class Resource(collections.MutableMapping):
         '''Ensure resource doesn't exist upstream
 
         By site, make sure resource is deleted. True if it is or was able to
-        get to the desired state, False if not and logged in `last_error`.
+        get to the desired state, False if not and logged in ``last_error``.
 
         Cache is cleared first thing and before return.
+
+        :rtype: bool
         '''
         self.clear_cache()
         try:
@@ -437,11 +440,11 @@ class Resource(collections.MutableMapping):
 
 
 class Network(Resource):
-    '''Network Resource
+    '''Network API Abstraction Model
 
     Subclass of Resource.
 
-    >>> n = Network(CLIENT, 1, network='8.8.8.0/32')
+    >>> n = Network(cidr='8.8.8.0/24', site_id=1)
     >>> n.exists()
     False
     >>> n.ensure()
@@ -455,20 +458,18 @@ class Network(Resource):
      u'is_ip': True,
      u'network_address': u'8.8.8.0',
      u'parent_id': 1,
-     u'prefix_length': 32,
+     u'prefix_length': 24,
      u'site_id': 1,
      u'state': u'assigned'}
-
+    >>>
     >>> n.purge()
     True
     >>> n.exists()
     False
+    >>> n.closest_parent()
+    <Network: 8.8.0.0/16>
 
-    Attributes:
-        self.net (str): Network
-        self.mask (str): Netmask
-    Options:
-        network (str): (kwarg) network in the form of "IP/NM"
+    :param cidr: CIDR for network
     '''
 
     def postinit(self, cidr=None):
@@ -510,8 +511,8 @@ class Network(Resource):
 
         Empty dictionary if no parent network
 
-        Returns:
-            dict
+        :returns: Parent resource
+        :rtype: pynsot.models.Network or dict
         '''
         self.ensure_client()
         site = getattr(self.client.sites(self['site_id']), self.resource_name)
@@ -532,10 +533,22 @@ class Device(Resource):
 
     Subclass of Resource.
 
-    Attributes:
-        hostname (str): Hostname
-    Options:
-        hostname (str): (kwarg) Hostname of device
+    >>> dev = Device(hostname='router1-nyc', site_id=1)
+    >>> dev.exists()
+    False
+    >>>
+    >>> dev.ensure()
+    True
+    >>>
+    >>> dev.existing_resource()
+    {u'attributes': {}, u'hostname': u'router1-nyc', u'id': 1, u'site_id': 1}
+    >>> dev.purge()
+    True
+    >>>
+    >>> dev.exists()
+    False
+
+    :param hostname: Device hostname
     '''
 
     def postinit(self, hostname=None):
@@ -569,26 +582,20 @@ class Interface(Resource):
 
     Subclass of Resource
 
-    Attributes:
-        addresses
-        description
-        device
-        type
-        mac_address
-        name
-        parent_id
-        speed
-
-    Options:
-        addresses (list)
-        description (str)
-        device (int or str): Required: If not device ID, will perform lookup by
-            hostname
-        type (int)
-        mac_address (str)
-        name (str): Required
-        parent_id (int)
-        speed (int)
+    :param addresses: Addresses on interface
+    :type addresses: list
+    :param description: Interface description
+    :param device: Required, device interface is on. TODO: broken as currently
+        implemented but will soon reflect the following type
+    :type device: pynsot.models.Device
+    :param type: Interface type as described by SNMP IF-TYPE's
+    :type type: int
+    :param mac_address: MAC of interface
+    :param name: Required, name of interface
+    :param parent_id: ID of parent interface
+    :type parent_id: int
+    :param speed: Speed of interface
+    :type speed: int
     '''
 
     def postinit(self, **kwargs):

--- a/pynsot/util.py
+++ b/pynsot/util.py
@@ -31,8 +31,8 @@ def get_result_key(payload, result_keys=None):
 def get_result(response):
     """
     Get the desired result from an API response.
-    :param response:
-        Requests API response object
+
+    :param response: Requests API response object
     """
     try:
         payload = response.json()


### PR DESCRIPTION

### Description

Documentation around the project in general went through a bit of a hardship, mostly felt around the Python API. This has mostly been mitigated the last few months and this is a step in the right direction for it.

### Why it's needed

This aims to close out issues #56, setting up for a closure of #95 

### How I know it works

`make html && google-chrome _build/html/python_api.html`