### PR TITLE
Fix #88 - Bugfix when parsing attribute values containing commas

### DIFF
--- a/pynsot/commands/cmd_devices.py
+++ b/pynsot/commands/cmd_devices.py
@@ -325,8 +325,7 @@ def update(ctx, attributes, hostname, id, site_id, attr_action, multi):
     uniquely identify the Device.
 
     The -a/--attributes option may be provided multiple times, once for each
-    key-value pair. You may also specify the -a a single time and separate
-    key-value pairs by a single comma.
+    key-value pair.
 
     When modifying attributes you have three actions to choose from:
 

--- a/pynsot/commands/cmd_interfaces.py
+++ b/pynsot/commands/cmd_interfaces.py
@@ -534,8 +534,7 @@ def update(ctx, attributes, addresses, description, id, mac_address, name,
     once for each IP address.
 
     The -a/--attributes option may be provided multiple times, once for each
-    key-value pair. You may also specify the -a a single time and separate
-    key-value pairs by a single comma.
+    key-value pair.
 
     When modifying attributes you have three actions to choose from:
 

--- a/pynsot/commands/cmd_networks.py
+++ b/pynsot/commands/cmd_networks.py
@@ -594,8 +594,7 @@ def update(ctx, attributes, cidr, id, state, site_id, attr_action, multi):
     provided -c/--cidr will be ignored.
 
     The -a/--attributes option may be provided multiple times, once for each
-    key-value pair. You may also specify the -a a single time and separate
-    key-value pairs by a single comma.
+    key-value pair.
 
     When modifying attributes you have three actions to choose from:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 fake-factory==0.5.0
+ipdb==0.9.3
 nsot==0.17.4
 py==1.4.26
 pytest==2.7.0


### PR DESCRIPTION
- Commas are now valid characters and are not treated specially to
  provide multiple values for a list-type Attribute.
- Attribute-values may not contain commands when performing bulk adds.
  This will be addressed in a future update.
- Updated requirements-dev: ipdb==0.9.3