### PR TITLE
Nesting Sites

### DIFF
--- a/pynsot/commands/cmd_sites.py
+++ b/pynsot/commands/cmd_sites.py
@@ -30,6 +30,7 @@ DISPLAY_FIELDS = (
     ('id', 'ID'),
     ('name', 'Name'),
     ('description', 'Description'),
+    ('parent', 'Parent'),
 )
 
 
@@ -190,7 +191,8 @@ def remove(ctx, id):
 @click.option(
     '-p',
     '--parent',
-    type=int
+    metavar='PARENT',
+    help='ID of parent site'
 )
 @click.pass_context
 def update(ctx, description, id, name, parent):

--- a/pynsot/commands/cmd_sites.py
+++ b/pynsot/commands/cmd_sites.py
@@ -187,15 +187,20 @@ def remove(ctx, id):
     metavar='NAME',
     help='The name of the Site.',
 )
+@click.option(
+    '-p',
+    '--parent',
+    type=int
+)
 @click.pass_context
-def update(ctx, description, id, name):
+def update(ctx, description, id, name, parent):
     """
     Update a Site.
 
     When updating a Site you must provide the unique ID (-i/--id) and at least
-    one of the -n/--name or -d/--description arguments.
+    one of the -n/--name, -p/--parent or -d/--description arguments.
     """
-    if name is None and description is None:
+    if name is None and description is None and parent is None:
         msg = 'You must supply at least one of -n/--name or -d/--description'
         raise click.UsageError(msg)
 

--- a/pynsot/commands/cmd_sites.py
+++ b/pynsot/commands/cmd_sites.py
@@ -66,8 +66,14 @@ def cli(ctx):
     help='The name of the Site.',
     required=True,
 )
+@click.option(
+    '-p',
+    '--parent',
+    metavar='PARENT',
+    help='ID of parent site'
+)
 @click.pass_context
-def add(ctx, description, name):
+def add(ctx, description, name, parent):
     """
     Add a new Site.
 


### PR DESCRIPTION
This is a PR to help solve issue dropbox/nsot#215.  Added `-p` option to `nsot sites add` and 
`nsot sites update`. It allows users to set the parent in nsot's Site model to the site id of the parent site.