### PR TITLE
Fix tests that are broken with the latest version of NSoT

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 fake-factory==0.5.0
 ipdb==0.9.3
-nsot==0.17.4
+nsot==1.0.13
 py==1.4.26
 pytest==2.7.0
 pytest-django==2.9.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,7 +48,7 @@ def test_site_add(client):
 
         # Try to add the same site again and fail.
         result = runner.run("sites add -n Foo -d 'Foo site.'")
-        expected_output = 'Site with this name already exists.\n'
+        expected_output = 'site with this name already exists.\n'
         assert result.exit_code == 1
         assert expected_output in result.output
 
@@ -711,7 +711,7 @@ def test_networks_subcommands(site_client):
 
         # Test closest_parent PASS w/ non-existent network
         result = runner.run('networks list -c 10.10.10.104/32 closest_parent')
-        assert_output(result, ['10.0.0.0', '24'])
+        assert_output(result, ['10.10.10.0', '24'])
 
         # Test closest_parent FAIL w/ non-existent parent
         result = runner.run('networks list -c 1.2.3.4/32 closest_parent')
@@ -738,8 +738,8 @@ def test_networks_allocation(site_client, device, network, interface):
         result = runner.run(
             'networks list -c 10.20.30.0/24 next_network -n 2 -p 28'
         )
-        assert_output(result, ['10.20.30.0', '28'])
         assert_output(result, ['10.20.30.16', '28'])
+        assert_output(result, ['10.20.30.32', '28'])
 
         # Test next_address
         runner.run('networks add -c 10.20.30.3/32')


### PR DESCRIPTION
* Bump nsot to current latest version
* Fix capitalization in `test_site_add()`
* Fix wrong network in `test_networks_subcommands()`
  * 10.10.10.0/24 should be the parent network since it gets created on line 678
* Fix wrong networks in `test_networks_allocation()`
  * 10.20.30.1/32 is assigned, so 10.20.30/28 should be off-limits

The cases of incorrect networks were modified based on my interpretation
of the test code. Please let me know if I'm wrong and they truly
_should_ be the old values.