### PR TITLE
Fix #125 - Support natural key when working with interfaces

### DIFF
--- a/pynsot/app.py
+++ b/pynsot/app.py
@@ -58,7 +58,7 @@ GREP_FORMATS = {
     'addresses': '%(network_address)s/%(prefix_length)s',  # Same as networks
     'assignments': '%(hostname)s:%(interface_name)s:%(address)s',
     'attributes': '%(resource_name)s:%(name)s',
-    'interfaces': '%(device)s:%(name)s',
+    'interfaces': '%(device_hostname)s:%(name)s',
     'sites': '%(name)s',
 }
 

--- a/pynsot/commands/cmd_interfaces.py
+++ b/pynsot/commands/cmd_interfaces.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 # field names oto their human-readable form when calling .print_list().
 DISPLAY_FIELDS = (
     ('id', 'ID'),
-    ('device', 'Device'),
+    ('device_hostname', 'Device'),
     ('name', 'Name'),
     ('mac_address', 'MAC'),
     ('addresses', 'Addresses'),
@@ -38,7 +38,8 @@ DISPLAY_FIELDS = (
 # Fields to display when viewing a single record.
 VERBOSE_FIELDS = (
     ('id', 'ID'),
-    ('device', 'Device'),
+    ('device', 'Device ID'),
+    ('device_hostname', 'Device'),
     ('name', 'Name'),
     ('mac_address', 'MAC'),
     ('addresses', 'Addresses'),
@@ -216,7 +217,6 @@ def add(ctx, attributes, addresses, device, description, mac_address,
     '-i',
     '--id',
     metavar='ID',
-    type=int,
     help='Unique ID of the Interface being retrieved.',
 )
 @click.option(
@@ -297,6 +297,10 @@ def list(ctx, attributes, delimited, device, description, grep, id, limit,
 
     When listing Interfaces, all objects are displayed by default. You
     optionally may lookup a single Interfaces by ID using the -i/--id option.
+    The ID can either be the numeric ID of the Interface, or the combination of
+    the device's hostname and the Interface name separated by a colon.
+
+    Example: switch-nyc3:Ethernet2
 
     You may limit the number of results using the -l/--limit option.
 
@@ -315,8 +319,8 @@ def list(ctx, attributes, delimited, device, description, grep, id, limit,
     # FIXME(jathan): If it's not a digit, it's a hostname? This is a hack for
     # the mixed use of natural_key vs id. We can do better "somehow".
     if device and not device.isdigit():
-        log.debug('Device is hostname! Converting device => device__hostname')
-        data['device__hostname'] = data.pop('device')
+        log.debug('Device is hostname! Converting device => device_hostname')
+        data['device_hostname'] = data.pop('device')
 
     # If we aren't passing a sub-command, just call list(), otherwise let it
     # fallback to default behavior.
@@ -373,7 +377,6 @@ def networks(ctx, *args, **kwargs):
     '-i',
     '--id',
     metavar='ID',
-    type=int,
     help='Unique ID of the Interface being deleted.',
     required=True,
 )
@@ -392,7 +395,13 @@ def remove(ctx, id, site_id):
 
     You must provide a Site ID using the -s/--site-id option.
 
-    When removing an Interface, you must provide the unique ID using -i/--id.
+    When removing an Interface, you must provide the ID of the Interface using
+    -i/--id. The ID can either be the numeric ID of the Interface or the
+    combination of the device's hostname and Interfaces name separated by a
+    colon.
+
+    Example: switch-nyc3:Ethernet2
+
     You may retrieve the ID for an Interface by parsing it from the list of
     Interfaces for a given Site:
 
@@ -430,7 +439,6 @@ def remove(ctx, id, site_id):
     '-i',
     '--id',
     metavar='ID',
-    type=int,
     help='Unique ID of the Interface being updated.',
     required=True,
 )
@@ -519,8 +527,12 @@ def update(ctx, attributes, addresses, description, id, mac_address, name,
 
     You must provide a Site ID using the -s/--site-id option.
 
-    When updating an Interface you must provide the unique ID (-i/--id) and at
-    least one of the optional arguments.
+    When updating an Interface you must provide the ID (-i/--id) and at least
+    one of the optional arguments. The ID can either be the numeric ID of the
+    Interface of the the combination of the device's hostname and the interface
+    name separated by a colon.
+
+    Example: switch-nyc3:Ethernet2
 
     If you wish to assign addresses, you may specify the -c/--addresses option
     once for each IP address.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -934,6 +934,12 @@ def test_interfaces_list(site_client, device):
         assert result.exit_code == 0
         assert result.output == expected_output
 
+        # Query by natural key
+        result = runner.run('interfaces list -i {0}:eth1'.format(hostname))
+        assert 'eth1' in result.output
+        assert str(device_id) in result.output
+        assert result.exit_code == 0
+
         ###########
         # Filtering
         ###########
@@ -979,6 +985,7 @@ def test_interfaces_list(site_client, device):
 def test_interfaces_subcommands(site_client, device):
     """Test ``nsot interfaces list ... {subcommand}``."""
     device_id = device['id']
+    device_hostname = device['hostname']
 
     runner = CliRunner(site_client.config)
     with runner.isolated_filesystem():
@@ -997,34 +1004,46 @@ def test_interfaces_subcommands(site_client, device):
         assert i1.exit_code == 0
 
         # Test addresses
-        result = runner.run(
-            'interfaces list -D %s -n eth0 -N addresses' % device_id
-        )
-        assert result.exit_code == 0
-        assert result.output == '10.10.10.1/32\n10.10.10.2/32\n'
+        cmds = [
+            'interfaces list -D %s -n eth0 -N addresses' % device_id,
+            'interfaces list -i %s:eth0 -N addresses' % device_hostname
+        ]
+
+        for cmd in cmds:
+            result = runner.run(cmd)
+            assert result.exit_code == 0
+            assert result.output == '10.10.10.1/32\n10.10.10.2/32\n'
 
         # Test networks
-        result = runner.run(
-            'interfaces list -D %s -n eth0 -N networks' % device_id
-        )
-        assert result.exit_code == 0
-        assert result.output == '10.10.10.0/24\n'
+        cmds = [
+            'interfaces list -D %s -n eth0 -N networks' % device_id,
+            'interfaces list -i %s:eth0 -N networks' % device_hostname
+        ]
+
+        for cmd in cmds:
+            result = runner.run(cmd)
+            assert result.exit_code == 0
+            assert result.output == '10.10.10.0/24\n'
 
         # Test assignments
-        result = runner.run(
-            'interfaces list -D %s -n eth0 -N assignments' % device_id
-        )
-        expected_output = (
-            'foo-bar1:eth0:10.10.10.1/32\n'
-            'foo-bar1:eth0:10.10.10.2/32\n'
-        )
-        assert result.exit_code == 0
-        assert result.output == expected_output
+        cmds = [
+            'interfaces list -D %s -n eth0 -N assignments' % device_id,
+            'interfaces list -i %s:eth0 -N assignments' % device_hostname
+        ]
+        for cmd in cmds:
+            result = runner.run(cmd)
+            expected_output = (
+                'foo-bar1:eth0:10.10.10.1/32\n'
+                'foo-bar1:eth0:10.10.10.2/32\n'
+            )
+            assert result.exit_code == 0
+            assert result.output == expected_output
 
 
 def test_interfaces_update(site_client, device):
     """Test ``nsot interfaces update``."""
     device_id = device['id']
+    hostname = device['hostname']
 
     runner = CliRunner(site_client.config)
     with runner.isolated_filesystem():
@@ -1055,15 +1074,23 @@ def test_interfaces_update(site_client, device):
         child_ifc = site_client.interfaces.get(name='eth0:1')[0]
         child_id = child_ifc['id']
 
-        # Test attributes: update vlan=200
-        result = runner.run('interfaces update -i %s -a vlan=200' % parent_id)
-        assert result.exit_code == 0
-        assert 'Updated interface!' in result.output
+        # Test attributes: update vlan=N
+        cases = [
+            [200, parent_id],
+            [300, '%s:%s' % (hostname, parent_ifc['name'])],
+        ]
 
-        # Verify attribute update
-        result = runner.run('interfaces list -i %s' % parent_id)
-        assert result.exit_code == 0
-        assert 'vlan=200' in result.output
+        for vlan, identifier in cases:
+            result = runner.run(
+                'interfaces update -i %s -a vlan=%d' % (identifier, vlan)
+            )
+            assert result.exit_code == 0
+            assert 'Updated interface!' in result.output
+
+            # Verify attribute update
+            result = runner.run('interfaces list -i %s' % identifier)
+            assert result.exit_code == 0
+            assert 'vlan=%d' % (vlan) in result.output
 
         # Test parent: update eth0:1 parent to eth0
         result = runner.run(
@@ -1119,12 +1146,23 @@ def test_interfaces_update(site_client, device):
         assert result.exit_code == 0
 
 
-def test_interfaces_remove(site_client, interface):
+def test_interfaces_remove(site_client, device, interface):
     """Test ``nsot interfaces remove``."""
     runner = CliRunner(site_client.config)
     with runner.isolated_filesystem():
         # Just delete the interface we have.
         result = runner.run('interfaces remove -i %s' % interface['id'])
+        assert result.exit_code == 0
+        assert 'Removed interface!' in result.output
+
+
+def test_interfaces_remove_by_natural_key(site_client, device, interface):
+    """Test ``nsot interfaces remove`` via the natural key."""
+    runner = CliRunner(site_client.config)
+    with runner.isolated_filesystem():
+        # Just delete the interface we have, but by natural key this time.
+        identifier = '%s:%s' % (device['hostname'], interface['name'])
+        result = runner.run('interfaces remove -i %s' % identifier)
         assert result.exit_code == 0
         assert 'Removed interface!' in result.output
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -861,6 +861,7 @@ def test_interfaces_add(site_client, device):
 def test_interfaces_list(site_client, device):
     """Test ``nsot interfaces list``."""
     device_id = device['id']
+    hostname = device['hostname']
 
     runner = CliRunner(site_client.config)
     with runner.isolated_filesystem():
@@ -897,7 +898,7 @@ def test_interfaces_list(site_client, device):
 
         # Set query -q/--query
         result = runner.run('interfaces list -q vlan=100')
-        expected_output = '{0}:eth0\n{0}:eth1\n'.format(device_id)
+        expected_output = '{0}:eth0\n{0}:eth1\n'.format(hostname)
         assert result.exit_code == 0
         assert result.output == expected_output
 
@@ -908,19 +909,19 @@ def test_interfaces_list(site_client, device):
 
         # Set query display comma-delimited (-d/--delimited)
         result = runner.run('interfaces list -q vlan=100 -d')
-        expected_output = '{0}:eth0,{0}:eth1\n'.format(device_id)
+        expected_output = '{0}:eth0,{0}:eth1\n'.format(hostname)
         assert result.exit_code == 0
         assert result.output == expected_output
 
         # Set query w/ -l/--limit
         result = runner.run('interfaces list -l1 -q vlan=100')
-        expected_output = '{0}:eth0\n'.format(device_id)
+        expected_output = '{0}:eth0\n'.format(hostname)
         assert result.exit_code == 0
         assert result.output == expected_output
 
         # Set query w/ -l/--limit and -o/--offset
         result = runner.run('interfaces list -l1 -o1 -q vlan=100')
-        expected_output = '{0}:eth1\n'.format(device_id)
+        expected_output = '{0}:eth1\n'.format(hostname)
         assert result.exit_code == 0
         assert result.output == expected_output
 
@@ -929,14 +930,13 @@ def test_interfaces_list(site_client, device):
         expected_output = (
             '{0}:eth0 vlan=100\n'
             '{0}:eth1 vlan=100\n'
-        ).format(device_id)
+        ).format(hostname)
         assert result.exit_code == 0
         assert result.output == expected_output
 
         ###########
         # Filtering
         ###########
-        hostname = device['hostname']
 
         # Filter by -D/--device (by id)
         result = runner.run('interfaces list -D %s' % device_id)


### PR DESCRIPTION
The NSoT API supports identifying most things by either their unique ID
number, or by a natural key; the natural key for interfaces being the
combination of the device's hostname and the interface's name. Example:

  * Device: switch-nyc3
  * Interface: Ethernet2
  * Natural Key: switch-nyc3:Ethernet2

Since dropbox/nsot#253 added caching of the device hostname on the
Interface object, lookups using that natural key are much easier.

Similar to how the API overloads the ID to be either one of those
things, I've mirrored that in the CLI. It would probably be more
user-friendly to let the user do something like specify a device
with `-D` and the interface name with `-n` or something, but that
causes a conflict with `update` since it uses `-n` to update the name of
the interface.

Given that conflict, that would have created a special case for `update`
and I felt like consistency across the various commands takes precedence.
Requiring the user to concatenate the device hostname and interface name
is a little annoying, but I tried to document that in a clear way.