### PR TITLE
Strict allocations

### DIFF
--- a/pynsot/commands/cmd_networks.py
+++ b/pynsot/commands/cmd_networks.py
@@ -472,6 +472,13 @@ def reserved(ctx, *args, **kwargs):
     help='Return Networks matching this prefix length.',
     required=True
 )
+@click.option(
+    '-s',
+    '--strict-allocation',
+    metavar='STRICT_ALLOCATION',
+    is_flag=True,
+    help='Return Networks can be strictly allocated'
+)
 @click.pass_context
 def next_network(ctx, *args, **kwargs):
     """
@@ -488,6 +495,13 @@ def next_network(ctx, *args, **kwargs):
     metavar='NUM',
     type=int,
     help='Number of addresses to return.'
+)
+@click.option(
+    '-s',
+    '--strict-allocation',
+    metavar='STRICT_ALLOCATION',
+    is_flag=True,
+    help='Return Networks can be strictly allocated'
 )
 @click.pass_context
 def next_address(ctx, *args, **kwargs):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 fake-factory==0.5.0
 ipdb==0.9.3
-nsot==1.1.2
+nsot==1.1.3
 py==1.4.26
 pytest==2.7.0
 pytest-django==2.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 fake-factory==0.5.0
 ipdb==0.9.3
-nsot==1.1.1
+nsot==1.1.2
 py==1.4.26
 pytest==2.7.0
 pytest-django==2.9.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -753,6 +753,19 @@ def test_networks_allocation(site_client, device, network, interface):
         assert_output(result, ['10.20.30.4', '32'])
         assert_output(result, ['10.20.30.5', '32'])
 
+        #Test strict allocations
+        runner.run('networks add -c 10.2.1.0/24')
+        runner.run('networks add -c 10.2.1.0/25')
+        result = runner.run('networks list -c 10.2.1.0/24 next_network -p 28 -n 3 -s')
+        assert_output(result, ['10.2.1.128', '28'])
+        assert_output(result, ['10.2.1.144', '28'])
+        assert_output(result, ['10.2.1.160', '28'])
+
+        #Test strict allocations for next_address
+        result = runner.run('networks list -c 10.2.1.0/24 next_address -n 3 -s')
+        assert_output(result, ['10.2.1.128', '32'])
+        assert_output(result, ['10.2.1.129', '32'])
+        assert_output(result, ['10.2.1.130', '32'])
 
 def test_networks_update(site_client):
     """Test ``nsot networks update``."""


### PR DESCRIPTION
This pull request should be merged alongside dropbox/nsot#256, It allows a user to pass an 
`-s/--strict-allocation` flag to the `next_network` and `next_address` actions.