### PR TITLE
Add support for Circuits

### DIFF
--- a/pynsot/app.py
+++ b/pynsot/app.py
@@ -58,6 +58,7 @@ GREP_FORMATS = {
     'addresses': '%(network_address)s/%(prefix_length)s',  # Same as networks
     'assignments': '%(hostname)s:%(interface_name)s:%(address)s',
     'attributes': '%(resource_name)s:%(name)s',
+    'circuits': '%(name)s',
     'interfaces': '%(device_hostname)s:%(name)s',
     'sites': '%(name)s',
 }

--- a/pynsot/commands/cmd_circuits.py
+++ b/pynsot/commands/cmd_circuits.py
@@ -4,12 +4,11 @@
 Sub-command for Circuits
 """
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import logging
 
-from nsot.util import slugify
-
-from ..vendor import click
+from pynsot.util import slugify
+from pynsot.vendor import click
 from . import callbacks
 from .cmd_networks import DISPLAY_FIELDS as NETWORK_DISPLAY_FIELDS
 from .cmd_interfaces import DISPLAY_FIELDS as INTERFACE_DISPLAY_FIELDS
@@ -61,6 +60,7 @@ def cli(ctx):
     '-A',
     '--endpoint-a',
     metavar='INTERFACE_ID',
+    required=True,
     type=int,
     help='Unique ID of the interface of the A side of the Circuit',
 )
@@ -106,9 +106,6 @@ def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
 
     data = ctx.params
 
-    if endpoint_a is None:
-        raise click.UsageError('Missing option "-A" / "--endpoint-a"')
-
     # Remove empty values to facilitate default assignment
     if name is None:
         data.pop('name')
@@ -126,6 +123,12 @@ def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
     metavar='ATTRS',
     help='Filter Circuits by matching attributes (format: key=value).',
     multiple=True,
+)
+@click.option(
+    '-A',
+    '--endpoint-a',
+    metavar='INTERFACE_ID',
+    help='Filter to Circuits with endpoint_a interfaces that match this ID'
 )
 @click.option(
     '-g',
@@ -146,6 +149,12 @@ def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
     '--limit',
     metavar='LIMIT',
     help='Limit result to N resources.',
+)
+@click.option(
+    '-n',
+    '--name',
+    metavar='NAME',
+    help='Filter to Circuits matching this name.',
 )
 @click.option(
     '-N',
@@ -174,9 +183,15 @@ def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
     help='Unique ID of the Site this Circuit is under.',
     callback=callbacks.process_site_id,
 )
+@click.option(
+    '-Z',
+    '--endpoint-z',
+    metavar='INTERFACE_ID',
+    help='Filter to Circuits with endpoint_z interfaces that match this ID'
+)
 @click.pass_context
-def list(ctx, attributes, grep, id, limit, natural_key, offset, query,
-         site_id):
+def list(ctx, attributes, endpoint_a, endpoint_z, grep, id, limit, name,
+         natural_key, offset, query, site_id):
     """
     List existing Circuits for a Site.
 

--- a/pynsot/commands/cmd_circuits.py
+++ b/pynsot/commands/cmd_circuits.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+
+"""
+Sub-command for Circuits
+"""
+
+from __future__ import unicode_literals
+import logging
+
+from ..vendor import click
+from . import callbacks
+
+
+# Logger
+log = logging.getLogger(__name__)
+
+# Ordered list of 2-tuples of (field, display_name) used to translate object
+# field names oto their human-readable form when calling .print_list().
+DISPLAY_FIELDS = (
+    ('id', 'ID'),
+    ('name', 'Name'),
+    ('endpoint_a', 'Endpoint A'),
+    ('endpoint_z', 'Endpoint Z'),
+    ('attributes', 'Attributes'),
+)
+
+# Fields to display when viewing a single record.
+VERBOSE_FIELDS = DISPLAY_FIELDS
+
+
+# Main group
+@click.group()
+@click.pass_context
+def cli(ctx):
+    """
+    Circuit objects.
+
+    A Circuit resource represents a connection between two interfaces on a
+    device.
+    """
+
+
+# Add
+# TODO(npegg): support specifying interfaces using the natural key instead of
+# by ID when the API supports that
+@cli.command()
+@click.option(
+    '-a',
+    '--attributes',
+    metavar='ATTRS',
+    help='A key/value pair attached to this Circuit (format: key=value).',
+    multiple=True,
+    callback=callbacks.transform_attributes,
+)
+@click.option(
+    '-A',
+    '--endpoint-a',
+    metavar='INTERFACE_ID',
+    type=int,
+    help='Unique ID of the interface of the A side of the Circuit',
+)
+@click.option(
+    '-n',
+    '--name',
+    metavar='NAME',
+    type=str,
+    help='The name of the Circuit.',
+)
+@click.option(
+    '-s',
+    '--site-id',
+    metavar='SITE_ID',
+    type=int,
+    help='Unique ID of the Site this Circuit is under. [required]',
+    callback=callbacks.process_site_id,
+)
+@click.option(
+    '-Z',
+    '--endpoint-z',
+    metavar='INTERFACE_ID',
+    type=int,
+    help='Unique ID of the interface on the Z side of the Circuit',
+)
+@click.pass_context
+def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
+    """
+    Add a new Circuit.
+
+    You must provide the A side of the circuit using the -A/--endpoint-a
+    option. The Z side is recommended but may be left blank, such as in cases
+    where it is not an Interface that is tracked by NSoT (like a provider's
+    interface).
+
+    The name (-n/--name) is optional. If it is not specified, it will be
+    generated for you in the form of:
+    {device_a}:{interface_a}_{device_z}:{interface_z}
+
+    If you wish to add attributes, you may specify the -a/--attributes
+    option once for each key/value pair.
+    """
+
+    data = ctx.params
+
+    if endpoint_a is None:
+        raise click.UsageError('Missing option "-A" / "--endpoint-a"')
+
+    # Remove empty values to facilitate default assignment
+    if name is None:
+        data.pop('name')
+    if endpoint_z is None:
+        data.pop('endpoint_z')
+
+    ctx.obj.add(data)
+
+
+# List
+@cli.command()
+@click.option(
+    '-a',
+    '--attributes',
+    metavar='ATTRS',
+    help='Filter Circuits by matching attributes (format: key=value).',
+    multiple=True,
+)
+@click.option(
+    '-g',
+    '--grep',
+    is_flag=True,
+    help='Display list results in a grep-friendly format.',
+    default=False,
+    show_default=True,
+)
+@click.option(
+    '-i',
+    '--id',
+    metavar='ID',
+    help='Unique ID of the Circuit being retrieved.',
+)
+@click.option(
+    '-l',
+    '--limit',
+    metavar='LIMIT',
+    help='Limit result to N resources.',
+)
+@click.option(
+    '-N',
+    '--natural-key',
+    is_flag=True,
+    help='Display list results by their natural key',
+    default=False,
+    show_default=True,
+)
+@click.option(
+    '-o',
+    '--offset',
+    metavar='OFFSET',
+    help='Skip the first N resources.',
+)
+@click.option(
+    '-q',
+    '--query',
+    metavar='QUERY',
+    help='Perform a set query using Attributes and output matching Circuits.'
+)
+@click.option(
+    '-s',
+    '--site-id',
+    metavar='SITE_ID',
+    help='Unique ID of the Site this Circuit is under.',
+    callback=callbacks.process_site_id,
+)
+@click.pass_context
+def list(ctx, attributes, grep, id, limit, natural_key, offset, query,
+         site_id):
+    """
+    List existing Circuits for a Site.
+
+    """
+
+    ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
+
+
+# Update
+@cli.command()
+@click.option(
+    '-a',
+    '--attributes',
+    metavar='ATTRS',
+    help='A key/value pair attached to this Circuit (format: key=value).',
+    multiple=True,
+    callback=callbacks.transform_attributes,
+)
+@click.option(
+    '-A',
+    '--endpoint-a',
+    metavar='INTERFACE_ID',
+    type=int,
+    help='Unique ID of the interface of the A side of the Circuit',
+)
+@click.option(
+    '-i',
+    '--id',
+    metavar='ID',
+    help='Unique ID of the Circuit being retrieved.',
+    required=True,
+)
+@click.option(
+    '-n',
+    '--name',
+    metavar='NAME',
+    type=str,
+    help='The name of the Circuit.',
+)
+@click.option(
+    '-s',
+    '--site-id',
+    metavar='SITE_ID',
+    type=int,
+    help='Unique ID of the Site this Circuit is under. [required]',
+    callback=callbacks.process_site_id,
+)
+@click.option(
+    '-Z',
+    '--endpoint-z',
+    metavar='INTERFACE_ID',
+    type=int,
+    help='Unique ID of the interface on the Z side of the Circuit',
+)
+@click.option(
+    '--add-attributes',
+    'attr_action',
+    flag_value='add',
+    default=True,
+    help=(
+        'Causes attributes to be added. This is the default and providing it '
+        'will have no effect.'
+    )
+)
+@click.option(
+    '--delete-attributes',
+    'attr_action',
+    flag_value='delete',
+    help=(
+        'Causes attributes to be deleted instead of updated. If combined with'
+        'with --multi the attribute will be deleted if either no value is '
+        'provided, or if attribute no longer has an valid values.'
+    ),
+)
+@click.option(
+    '--replace-attributes',
+    'attr_action',
+    flag_value='replace',
+    help=(
+        'Causes attributes to be replaced instead of updated. If combined '
+        'with --multi, the entire list will be replaced.'
+    ),
+)
+@click.pass_context
+def update(ctx, attributes, endpoint_a, id, name, site_id, endpoint_z, 
+           attr_action):
+    """
+    Update a Circuit.
+
+    You must either have a Site ID configured in your .pysnotrc file or specify
+    one using the -s/--site-id option.
+
+    The -a/--attributes option may be provided multiple times, once for each
+    key-value pair.
+
+    When modifying attributes you have three actions to choose from:
+
+    * Add (--add-attributes). This is the default behavior that will add
+    attributes if they don't exist, or update them if they do.
+
+    * Delete (--delete-attributes). This will cause attributes to be
+    deleted. If combined with --multi the attribute will be deleted if
+    either no value is provided, or if the attribute no longer contains a
+    valid value.
+
+    * Replace (--replace-attributes). This will cause attributes to
+    replaced. If combined with --multi and multiple attributes of the same
+    name are provided, only the last value provided will be used.
+    """
+
+    if not any([attributes, endpoint_a, name, endpoint_z]):
+        msg = 'You must supply at least one of the optional arguments.'
+        raise click.UsageError(msg)
+
+    ctx.obj.update(ctx.params)
+
+
+# Remove
+@cli.command()
+@click.option(
+    '-i',
+    '--id',
+    metavar='ID',
+    help='Unique ID of the Circuit being deleted.',
+    required=True,
+)
+@click.option(
+    '-s',
+    '--site-id',
+    metavar='SITE_ID',
+    type=int,
+    help='Unique ID of the Site this Circuit is under.',
+    callback=callbacks.process_site_id,
+)
+@click.pass_context
+def remove(ctx, id, site_id):
+    ctx.obj.remove(**ctx.params)

--- a/pynsot/commands/cmd_circuits.py
+++ b/pynsot/commands/cmd_circuits.py
@@ -7,6 +7,8 @@ Sub-command for Circuits
 from __future__ import unicode_literals
 import logging
 
+from nsot.util import slugify
+
 from ..vendor import click
 from . import callbacks
 from .cmd_networks import DISPLAY_FIELDS as NETWORK_DISPLAY_FIELDS
@@ -187,6 +189,10 @@ def list(ctx, attributes, grep, id, limit, natural_key, offset, query,
     You may limit the number of results using the -l/--limit option.
     """
 
+    # If we get a name as an identifier, slugify it
+    if ctx.params.get('id') and not ctx.params['id'].isdigit():
+        ctx.params['id'] = slugify(ctx.params['id'])
+
     # Don't list interfaces if a subcommand is invoked
     if ctx.invoked_subcommand is None:
         ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
@@ -324,6 +330,10 @@ def update(ctx, attributes, endpoint_a, id, name, site_id, endpoint_z,
     name are provided, only the last value provided will be used.
     """
 
+    # If we get a name as an identifier, slugify it
+    if ctx.params.get('id') and not ctx.params['id'].isdigit():
+        ctx.params['id'] = slugify(ctx.params['id'])
+
     if not any([attributes, endpoint_a, name, endpoint_z]):
         msg = 'You must supply at least one of the optional arguments.'
         raise click.UsageError(msg)
@@ -360,5 +370,9 @@ def remove(ctx, id, site_id):
     optionally may look up a single Circuit by ID or Name using the -i/--id
     option.
     """
+
+    # If we get a name as an identifier, slugify it
+    if ctx.params.get('id') and not ctx.params['id'].isdigit():
+        ctx.params['id'] = slugify(ctx.params['id'])
 
     ctx.obj.remove(**ctx.params)

--- a/pynsot/commands/cmd_circuits.py
+++ b/pynsot/commands/cmd_circuits.py
@@ -9,6 +9,9 @@ import logging
 
 from ..vendor import click
 from . import callbacks
+from .cmd_networks import DISPLAY_FIELDS as NETWORK_DISPLAY_FIELDS
+from .cmd_interfaces import DISPLAY_FIELDS as INTERFACE_DISPLAY_FIELDS
+from .cmd_devices import DISPLAY_FIELDS as DEVICE_DISPLAY_FIELDS
 
 
 # Logger
@@ -114,7 +117,7 @@ def add(ctx, attributes, endpoint_a, name, site_id, endpoint_z):
 
 
 # List
-@cli.command()
+@cli.group(invoke_without_command=True)
 @click.option(
     '-a',
     '--attributes',
@@ -175,9 +178,48 @@ def list(ctx, attributes, grep, id, limit, natural_key, offset, query,
     """
     List existing Circuits for a Site.
 
+    You must either have a Site ID configured in your .pysnotrc file or specify
+    one using the -s/--site-id option.
+
+    When listing Circuits, all objects are displayed by default. You optionally
+    may look up a single Circuit by ID or Name using the -i/--id option.
+
+    You may limit the number of results using the -l/--limit option.
     """
 
-    ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
+    # Don't list interfaces if a subcommand is invoked
+    if ctx.invoked_subcommand is None:
+        ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
+
+
+@list.command()
+@click.pass_context
+def addresses(ctx, *args, **kwargs):
+    """ Show addresses for the Interfaces on this Circuit. """
+
+    callbacks.list_subcommand(
+        ctx, display_fields=NETWORK_DISPLAY_FIELDS, my_name=ctx.info_name
+    )
+
+
+@list.command()
+@click.pass_context
+def devices(ctx, *args, **kwargs):
+    """ Show Devices connected by this Circuit. """
+
+    callbacks.list_subcommand(
+        ctx, display_fields=DEVICE_DISPLAY_FIELDS, my_name=ctx.info_name
+    )
+
+
+@list.command()
+@click.pass_context
+def interfaces(ctx, *args, **kwargs):
+    """ Show Interfaces connected by this Circuit. """
+
+    callbacks.list_subcommand(
+        ctx, display_fields=INTERFACE_DISPLAY_FIELDS, my_name=ctx.info_name
+    )
 
 
 # Update
@@ -256,7 +298,7 @@ def list(ctx, attributes, grep, id, limit, natural_key, offset, query,
     ),
 )
 @click.pass_context
-def update(ctx, attributes, endpoint_a, id, name, site_id, endpoint_z, 
+def update(ctx, attributes, endpoint_a, id, name, site_id, endpoint_z,
            attr_action):
     """
     Update a Circuit.
@@ -308,4 +350,15 @@ def update(ctx, attributes, endpoint_a, id, name, site_id, endpoint_z,
 )
 @click.pass_context
 def remove(ctx, id, site_id):
+    """
+    Remove a Circuit.
+
+    You must either have a Site ID configured in your .pysnotrc file or specify
+    one using the -s/--site-id option.
+
+    When removing Circuits, all objects are displayed by default. You
+    optionally may look up a single Circuit by ID or Name using the -i/--id
+    option.
+    """
+
     ctx.obj.remove(**ctx.params)

--- a/pynsot/util.py
+++ b/pynsot/util.py
@@ -50,3 +50,20 @@ def dict_to_cidr(obj):
         Dict of an Network object
     """
     return '%s/%s' % (obj['network_address'], obj['prefix_length'])
+
+
+def slugify(s):
+    """
+    Slugify a string for use in URLs. This mirrors ``nsot.util.slugify()``.
+
+    :param s:
+        String to slugify
+    """
+
+    disallowed_chars = ['/']
+    replacement = '_'
+
+    for char in disallowed_chars:
+        s = s.replace(char, replacement)
+
+    return s

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 fake-factory==0.5.0
 ipdb==0.9.3
+nsot==1.1.1
 py==1.4.26
 pytest==2.7.0
 pytest-django==2.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 fake-factory==0.5.0
 ipdb==0.9.3
-nsot==1.0.13
 py==1.4.26
 pytest==2.7.0
 pytest-django==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==6.2
 PTable==0.9.2
 netaddr==0.7.18
-nsot==1.1.1
 rcfile==0.1.4
 requests==2.9.1
 slumber==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click==6.2
 PTable==0.9.2
 netaddr==0.7.18
+nsot==1.1.1
 rcfile==0.1.4
 requests==2.9.1
 slumber==0.7.1

--- a/tests/app/test_circuits.py
+++ b/tests/app/test_circuits.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+
+"""
+Test Circuits in the CLI app.
+"""
+
+from __future__ import absolute_import, unicode_literals
+import logging
+
+from tests.fixtures import (attribute, client, config, device, interface,
+                            network, runner, site, site_client)
+from tests.fixtures.circuits import (circuit, circuit_attributes, device_a,
+                                     device_z, interface_a, interface_z)
+from tests.util import assert_output, assert_outputs
+
+
+log = logging.getLogger(__name__)
+
+
+def test_circuits_add(runner, interface_a, interface_z):
+    """ Test adding a normal circuit """
+
+    with runner.isolated_filesystem():
+        # Add a circuit with interfaces on each end
+        result = runner.run(
+            'circuits add -A {0} -Z {1} -n add_test1'.format(
+                interface_a['id'],
+                interface_z['id']
+            )
+        )
+        assert_output(result, ['Added circuit!'])
+
+        # Verify the circuit was created by listing
+        result = runner.run('circuits list')
+        assert_output(result, ['add_test1'])
+
+
+def test_circuits_add_single_sided(runner, interface_a):
+    """ Add a circuit with no remote end """
+
+    with runner.isolated_filesystem():
+        result = runner.run(
+            'circuits add -A {0} -n add_test2'.format(interface_a['id'])
+        )
+
+        assert_output(result, ['Added circuit!'])
+
+        result = runner.run('circuits list')
+        assert_output(result, ['add_test2'])
+
+
+def test_circuits_add_intf_reuse(runner, interface_a):
+    """
+    Try creating two circuits with the same interface, which should fail
+    """
+
+    with runner.isolated_filesystem():
+        cmd = 'circuits add -A {0} -n {1}'
+
+        result = runner.run(cmd.format(interface_a['id'], 'circuit1'))
+        assert result.exit_code == 0
+
+        result = runner.run(cmd.format(interface_a['id'], 'bad_circuit'))
+        assert result.exit_code != 0
+        assert 'endpoint_a:  This field must be unique' in result.output
+
+
+def test_circuits_add_dupe_name(runner, interface_a, interface_z):
+    """
+    Try creating two circuits with the same name, which should fail
+    """
+
+    with runner.isolated_filesystem():
+        cmd = 'circuits add -A {0} -n foo'
+
+        result = runner.run(cmd.format(interface_a['id']))
+        assert result.exit_code == 0
+
+        result = runner.run(cmd.format(interface_z['id']))
+        assert result.exit_code != 0
+        assert 'circuit with this name already exists' in result.output
+
+
+def test_circuits_list(runner, circuit):
+    """ Make sure we can list out a circuit """
+
+    circuit_name = 'test_circuit'
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list')
+        assert_output(result, [circuit_name])
+
+        result = runner.run('circuits list -i {}'.format(circuit_name))
+        assert_output(result, [circuit_name])
+
+
+def test_circuits_list_nonexistant(runner):
+    """ Listing a non-existant circuit should fail """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -i nopenopenope')
+
+        assert result.exit_code != 0
+        assert 'No such Circuit found' in result.output
+
+
+def test_circuits_list_natural_key_output(runner, circuit):
+    """ Natural key output should just list the circuit names """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -N')
+
+        assert result.exit_code == 0
+        assert result.output == "test_circuit\n"
+
+
+def test_circuits_list_grep_output(runner, circuit):
+    """ grep output should list circuit names with all the attributes """
+
+    expected_output = (
+        "test_circuit owner=alice\n"
+        "test_circuit vendor=lasers go pew pew\n"
+    )
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -g')
+
+        assert result.exit_code == 0
+        assert result.output == expected_output
+
+
+def test_circuits_list_addresses(runner, circuit, interface_a, interface_z):
+    """ Test listing out a circuit's interface addresses """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -i {} addresses'.format(
+            circuit['id']
+        ))
+
+        assert_outputs(
+            result,
+            [
+                [interface_a['addresses'][0].split('/')[0]],
+                [interface_z['addresses'][0].split('/')[0]]
+            ]
+        )
+
+
+def test_circuits_list_devices(runner, circuit, device_a, device_z):
+    """ Test listing out a circuit's devices """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -i {} devices'.format(
+            circuit['id']
+        ))
+
+        assert_outputs(
+            result,
+            [
+                [device_a['hostname']],
+                [device_z['hostname']]
+            ]
+        )
+
+
+def test_circuits_list_interfaces(runner, circuit, interface_a, interface_z):
+    """ Test listing out a circuit's interfaces """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits list -i {} interfaces'.format(
+            circuit['id']
+        ))
+
+        assert_outputs(
+            result,
+            [
+                [interface_a['device_hostname'], interface_a['name']],
+                [interface_z['device_hostname'], interface_z['name']]
+            ]
+        )
+
+
+def test_circuits_remove(runner, circuit):
+    """ Make sure we can remove an existing circuit """
+
+    circuit_name = 'test_circuit'
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits remove -i {}'.format(circuit_name))
+        assert result.exit_code == 0
+
+
+def test_circuits_update_name(runner, circuit):
+    """ Test update by changing the circuit name """
+
+    old_name = 'test_circuit'
+    new_name = 'awesome_circuit'
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits update -i {} -n {}'.format(
+            old_name,
+            new_name
+        ))
+        assert result.exit_code == 0
+
+        # Make sure we can look up the circuit by its new name
+        result = runner.run('circuits list -i {}'.format(new_name))
+        assert_output(result, [new_name])
+
+        # Make sure the old name doesn't exist
+        result = runner.run('circuits list -i {}')
+        assert result.exit_code != 0
+        assert 'No such Circuit found' in result.output
+
+
+def test_circuits_update_interface(runner, circuit, interface):
+    """ Test updating a circuit's Z side interface """
+
+    with runner.isolated_filesystem():
+        result = runner.run('circuits update -i {0} -Z {1}'.format(
+            circuit['name'], interface['id']
+        ))
+        assert_output(result, ['Updated circuit!'])

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -12,6 +12,7 @@ import pytest
 from pytest_django.fixtures import live_server, django_user_model
 
 from pynsot.client import get_api_client
+from tests.util import CliRunner
 
 
 __all__ = ('django_user_model', 'live_server')
@@ -94,6 +95,11 @@ def site_client(client, site):
     client.config['default_site'] = site['id']
     client.default_site = site['id']
     return client
+
+
+@pytest.fixture
+def runner(site_client):
+    return CliRunner(site_client.config)
 
 
 @pytest.fixture

--- a/tests/fixtures/circuits.py
+++ b/tests/fixtures/circuits.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+
+from tests.fixtures import site_client
+
+
+@pytest.fixture
+def circuit_attributes(site_client):
+    attr_names = [
+        'owner',
+        'vendor'
+    ]
+
+    attrs = ({'name': a, 'resource_name': 'Circuit'} for a in attr_names)
+    client = site_client.sites(site_client.default_site).attributes
+    return map(client.post, attrs)
+
+
+@pytest.fixture
+def device_a(site_client):
+    """ Device for the A side of the circuit """
+
+    return site_client.sites(site_client.default_site).devices.post(
+        {'hostname': 'foo-bar01'}
+    )
+
+
+@pytest.fixture
+def device_z(site_client):
+    """ Device for the Z side of the circuit """
+
+    return site_client.sites(site_client.default_site).devices.post(
+        {'hostname': 'foo-bar02'}
+    )
+
+
+@pytest.fixture
+def interface_a(site_client, device_a, network):
+    """ Interface for the A side of the circuit """
+
+    return site_client.sites(site_client.default_site).interfaces.post({
+        'device': device_a['id'],
+        'name': 'eth0',
+        'addresses': ['10.20.30.2/32'],
+    })
+
+
+@pytest.fixture
+def interface_z(site_client, device_z, network):
+    """ Interface for the Z side of the circuit """
+
+    return site_client.sites(site_client.default_site).interfaces.post({
+        'device': device_z['id'],
+        'name': 'eth0',
+        'addresses': ['10.20.30.3/32'],
+    })
+
+
+@pytest.fixture
+def circuit(site_client, circuit_attributes, interface_a, interface_z):
+    """ Circuit connecting interface_a to interface_z """
+
+    return site_client.sites(site_client.default_site).circuits.post({
+        'name': 'test_circuit',
+        'endpoint_a': interface_a['id'],
+        'endpoint_z': interface_z['id'],
+        'attributes': {
+            'owner': 'alice',
+            'vendor': 'lasers go pew pew',
+        },
+    })
+
+
+@pytest.fixture
+def dangling_circuit(site_client, interface):
+    """
+    Circuit where we only own the local site, remote (Z) end is a vendor
+    """
+
+    return site_client.sites(site_client.default_site).circuits.post({
+        'name': 'remote_vendor_circuit',
+        'endpoint_a': interface['id'],
+    })

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,7 +6,7 @@ Test the utils lib.
 
 import pytest  # noqa
 
-from pynsot.util import validate_cidr
+from pynsot.util import slugify, validate_cidr
 
 
 def test_validate_cidr():
@@ -25,3 +25,18 @@ def test_validate_cidr():
     assert not validate_cidr(object())
     assert not validate_cidr({})
     assert not validate_cidr([])
+
+
+def test_slugify():
+    cases = [
+        ('/', '_'),
+        ('my cool string', 'my cool string'),
+        ('Ethernet1/2', 'Ethernet1_2'),
+        (
+            'foo-bar1:xe-0/0/0.0_foo-bar2:xe-0/0/0.0',
+            'foo-bar1:xe-0_0_0.0_foo-bar2:xe-0_0_0.0'
+        ),
+    ]
+
+    for case, expected in cases:
+        assert slugify(case) == expected


### PR DESCRIPTION
Now that we have circuits in NSoT, the CLI needs to support them. This handles all the CRUD operations, as well as subcommands for list in the API: `devices`, `addresses`, and `interfaces`.

I also did a bit of refactoring of the tests to support doing set of tests per file (e.g. circuits in their own file). Since I added a set of fixtures for the Circuit tests, those went into their own file. `tests/fixtures.py` was moved to `test/fixtures/__init__.py` to support this and still maintain backwards compatibility of imports in the existing tests.
