### PR TITLE
Fix #120 - Correct spelling for Network "descendants" sub-command.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -768,14 +768,14 @@ Get the closest matching parent of a network, even if the network isn't found in
     | 1    10.0.0.0   8        False    4         None        allocated              |
     +--------------------------------------------------------------------------------+
 
-Descendents
+Descendants
 ~~~~~~~~~~~
 
 Recursively get all children of a network:
 
 .. code-block:: bash
 
-    $ nsot networks list -c 10.20.0.0/16 descendents
+    $ nsot networks list -c 10.20.0.0/16 descendants
     +------------------------------------------------------------------------------------+
     | ID   Network        Prefix   Is IP?   IP Ver.   Parent ID   State       Attributes |
     +------------------------------------------------------------------------------------+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -684,13 +684,18 @@ def test_networks_subcommands(site_client):
         assert_output(result, ['10.10.10.2', '32'])
         assert_output(result, ['10.10.10.3', '32'])
 
-        # Test descendents
-        result = runner.run('networks list -c 10.0.0.0/8 descendents')
+        # Test descendants
+        result = runner.run('networks list -c 10.0.0.0/8 descendants')
         assert_output(result, ['10.0.0.0', '24'])
         assert_output(result, ['10.10.10.0', '24'])
         assert_output(result, ['10.10.10.1', '32'])
         assert_output(result, ['10.10.10.2', '32'])
         assert_output(result, ['10.10.10.3', '32'])
+
+        # Assert descendents (typoed) includes deprecation warning
+        result2 = runner.run('networks list -c 10.0.0.0/8 descendents')
+        assert_output(result2, ['[WARNING]'])
+        assert result.output.splitlines() == result2.output.splitlines()[1:]
 
         # Test root
         result = runner.run('networks list -c 10.10.10.1/32 root')


### PR DESCRIPTION
* Corrected the spelling for the ``descendants`` sub-command on Networks. The
  old misspelled form of ``descendents`` will display a warning to users.