### PR TITLE
Change requirements*txt to use Compatible Release specifiers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 fake-factory~=0.5.0
 ipdb~=0.9.3
 nsot>=1.1.3,~=1.1.0
-py~=1.4.26
+py~=1.4.26,>=1.4.29
 pytest~=2.7.0
 pytest-django~=2.9.1
 pytest-pythonpath~=0.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
-fake-factory==0.5.0
-ipdb==0.9.3
-nsot==1.1.3
-py==1.4.26
-pytest==2.7.0
-pytest-django==2.9.1
-pytest-pythonpath==0.6
-Sphinx==1.3.6
-sphinx-autobuild==0.6.0
-sphinx-rtd-theme==0.1.9
+fake-factory~=0.5.0
+ipdb~=0.9.3
+nsot>=1.1.3,~=1.1.0
+py~=1.4.26
+pytest~=2.7.0
+pytest-django~=2.9.1
+pytest-pythonpath~=0.6.0
+Sphinx~=1.3.6
+sphinx-autobuild~=0.6.0
+sphinx-rtd-theme~=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-click==6.2
-PTable==0.9.2
-netaddr==0.7.18
-rcfile==0.1.4
-requests==2.9.1
-slumber==0.7.1
+click~=6.2.0
+PTable~=0.9.2
+netaddr~=0.7.18
+rcfile~=0.1.4
+requests~=2.9.1
+slumber~=0.7.1


### PR DESCRIPTION
This is a similar change to https://github.com/dropbox/nsot/pull/265

For the `nsot` requirement, I left it at `~=1.1.0` since API
deprecations could happen if we jump too far ahead on minor versions. I
also added a minimum version of `nsot` to ensure that tests run against
a version that has the APIs we need.

Going to hold off on merging this until https://github.com/dropbox/pynsot/pull/128 is merged since I'm sure a merge conflict in `requirements-dev.txt` will happen.