### PR TITLE
Pin IPython to 5.x

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 fake-factory~=0.5.0
 ipdb~=0.9.3
+ipython~=5.0
 nsot>=1.1.3,~=1.1.0
 py~=1.4.26,>=1.4.29
 pytest~=2.7.0


### PR DESCRIPTION
Travis started failing due to an error when trying to install IPython
6.0.0 with Python 2.7.x:
https://travis-ci.org/dropbox/pynsot/builds/236270172

I wasn't able to reproduce it locally on my machine (Ubuntu 16.04,
Python 2.7.12, pip 9.0.1) since it for some reason sticks to IPython
5.x, but this should at least fix Travis's problem.