### PR TITLE
Add set queries to `nsot circuits list`

### DIFF
--- a/pynsot/commands/cmd_circuits.py
+++ b/pynsot/commands/cmd_circuits.py
@@ -216,7 +216,10 @@ def list(ctx, attributes, endpoint_a, endpoint_z, grep, id, limit, name,
 
     # Don't list interfaces if a subcommand is invoked
     if ctx.invoked_subcommand is None:
-        ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
+        if query is not None:
+            ctx.obj.natural_keys_by_query(ctx.params)
+        else:
+            ctx.obj.list(ctx.params, display_fields=DISPLAY_FIELDS)
 
 
 @list.command()

--- a/tests/app/test_circuits.py
+++ b/tests/app/test_circuits.py
@@ -11,8 +11,9 @@ import pytest
 
 from tests.fixtures import (attribute, attributes, client, config, device,
                             interface, network, runner, site, site_client)
-from tests.fixtures.circuits import (circuit, circuit_attributes, device_a,
-                                     device_z, interface_a, interface_z)
+from tests.fixtures.circuits import (circuit, circuit_attributes,
+                                     attributeless_circuit, device_a, device_z,
+                                     interface_a, interface_z)
 from tests.util import assert_output, assert_outputs
 
 
@@ -94,6 +95,21 @@ def test_circuits_list(runner, circuit):
 
         result = runner.run('circuits list -i {}'.format(circuit_name))
         assert_output(result, [circuit_name])
+
+
+def test_circuits_list_query(runner, circuit, attributeless_circuit):
+    with runner.isolated_filesystem():
+        # Should result in an error
+        result = runner.run('circuits list -q "doesnt=exist"')
+        assert result.exit_code != 0
+        assert 'Attribute matching query does not exist' in result.output
+
+        # Test some basic set queries with the two circuits
+        result = runner.run('circuits list -q "owner=alice"')
+        assert result.output == "test_circuit\n"
+
+        result = runner.run('circuits list -q "-owner=alice"')
+        assert result.output == "attributeless_circuit\n"
 
 
 def test_circuits_list_nonexistant(runner):

--- a/tests/fixtures/circuits.py
+++ b/tests/fixtures/circuits.py
@@ -84,3 +84,14 @@ def dangling_circuit(site_client, interface):
         'name': 'remote_vendor_circuit',
         'endpoint_a': interface['id'],
     })
+
+
+@pytest.fixture
+def attributeless_circuit(site_client, interface):
+    """ Circuit with no attributes set """
+
+    return site_client.sites(site_client.default_site).circuits.post({
+        'name': 'attributeless_circuit',
+        'endpoint_a': interface['id'],
+        'attributes': {},
+    })


### PR DESCRIPTION
When this module was originally written I forgot to add querying when
`-q` is passed in to `nsot circuits list`. Oops. This adds that routing,
similar to the `nsot devices list` command`, as well as some tests
around some basic set queries.

Fixes #149.