### PR TITLE
Fixing typo in circuits list output when a circuit does not have addresses.

### DIFF
--- a/pynsot/app.py
+++ b/pynsot/app.py
@@ -129,10 +129,10 @@ class App(object):
     def singular(self):
         """Return singular form of resource_name. (e.g. "sites" -> "site")"""
         resource_name = self.resource_name
-        if resource_name.endswith('s') and resource_name != 'addresses':
-            resource_name = resource_name[:-1]
-        elif resource_name == 'addresses':
+        if resource_name == 'addresses':
             resource_name = 'address'
+        elif resource_name.endswith('s'):
+            resource_name = resource_name[:-1]
         return resource_name
 
     @property

--- a/pynsot/app.py
+++ b/pynsot/app.py
@@ -129,8 +129,10 @@ class App(object):
     def singular(self):
         """Return singular form of resource_name. (e.g. "sites" -> "site")"""
         resource_name = self.resource_name
-        if resource_name.endswith('s'):
+        if resource_name.endswith('s') and resource_name != 'addresses':
             resource_name = resource_name[:-1]
+        elif resource_name == 'addresses':
+            resource_name = 'address'
         return resource_name
 
     @property


### PR DESCRIPTION
- The `singular` function removed `s` but did not account for singular version of addresses needing to drop `es`.

**Here is the old error:** 
```
khardson@hostname:~$ nsot circuits list -i 10 addresses
No addresse found matching args: attributes=(), endpoint_a=None, endpoint_z=None, limit=None, name=None, offset=None, query=None!
```

**Here is the new error:**
```khardson@hostname:~/pynsot/pynsot/pynsot$ nsot circuits list -i 5 addresses
No address found matching args: attributes=(), endpoint_a=None, endpoint_z=None, limit=None, name=None, offset=None, query=None!
```
- I considered adding a rule to check if the resource name ended with `es` instead of hard coding `address`, but found this would conflict for `interfaces`.