### PR TITLE
Add --limit and --offset to Protocol and ProtocolType CLI

### DIFF
--- a/pynsot/commands/cmd_protocol_types.py
+++ b/pynsot/commands/cmd_protocol_types.py
@@ -133,10 +133,23 @@ def add(ctx, required_attributes, description, name, site_id):
     help='Unique ID of the Protocol Type being retrieved.',
 )
 @click.option(
+    '-l',
+    '--limit',
+    metavar='LIMIT',
+    type=int,
+    help='Limit result to N resources.',
+)
+@click.option(
     '-n',
     '--name',
     metavar='NAME',
     help='Filter to Protocol Type matching this name.'
+)
+@click.option(
+    '-o',
+    '--offset',
+    metavar='OFFSET',
+    help='Skip the first N resources.',
 )
 @click.option(
     '-s',
@@ -146,7 +159,7 @@ def add(ctx, required_attributes, description, name, site_id):
     callback=callbacks.process_site_id,
 )
 @click.pass_context
-def list(ctx, description, id, name, site_id):
+def list(ctx, description, id, limit, name, offset, site_id):
     """
     List existing Protocol Types for a Site.
 

--- a/pynsot/commands/cmd_protocols.py
+++ b/pynsot/commands/cmd_protocols.py
@@ -230,6 +230,19 @@ def add(ctx, auth_string, attributes, circuit, device, description, interface,
     ),
 )
 @click.option(
+    '-l',
+    '--limit',
+    metavar='LIMIT',
+    type=int,
+    help='Limit result to N resources.',
+)
+@click.option(
+    '-o',
+    '--offset',
+    metavar='OFFSET',
+    help='Skip the first N resources.',
+)
+@click.option(
     '-q',
     '--query',
     metavar='QUERY',
@@ -251,7 +264,7 @@ def add(ctx, auth_string, attributes, circuit, device, description, interface,
 )
 @click.pass_context
 def list(ctx, attributes, auth_string, circuit, delimited, description, device,
-         grep, id, interface, query, site_id, type):
+         grep, id, interface, limit, offset, query, site_id, type):
     """
     List existing Protocols for a Site.
 

--- a/tests/fixtures/protocol_types.py
+++ b/tests/fixtures/protocol_types.py
@@ -39,3 +39,20 @@ def protocol_attribute2(site_client):
             'resource_name': 'Protocol',
         }
     )
+
+
+@pytest.fixture
+def protocol_types(site_client):
+    """
+    A group of ProtocolTypes for testing limit/offset/etc.
+    """
+    protocol_types = []
+    site = site_client.sites(site_client.default_site)
+
+    for i in range(1, 6):
+        protocol_type = site.protocol_types.post({
+            'name': 'type{}'.format(i),
+        })
+        protocol_types.append(protocol_type)
+
+    return protocol_types

--- a/tests/fixtures/protocols.py
+++ b/tests/fixtures/protocols.py
@@ -14,7 +14,7 @@ def protocol(site_client, device_a, interface_a, circuit, protocol_type):
     Return a Protocol Object.
     """
     device_id = device_a['id']
-    interface_slug = '{device_hostname}:{name}'.format(**interface_a)
+    interface_slug = interface_a['name_slug']
     return site_client.sites(site_client.default_site).protocols.post(
         {
             'device': device_id,
@@ -27,7 +27,7 @@ def protocol(site_client, device_a, interface_a, circuit, protocol_type):
     )
 
 @pytest.fixture
-def protocol_attribute(site_client, protocol):
+def protocol_attribute(site_client):
     return site_client.sites(site_client.default_site).attributes.post(
         {
             'name':'boo',
@@ -37,7 +37,7 @@ def protocol_attribute(site_client, protocol):
     )
 
 @pytest.fixture
-def protocol_attribute2(site_client, protocol):
+def protocol_attribute2(site_client):
     return site_client.sites(site_client.default_site).attributes.post(
         {
             'name':'foo',
@@ -46,3 +46,30 @@ def protocol_attribute2(site_client, protocol):
         }
     )
 
+
+@pytest.fixture
+def protocols(site_client, protocol_type, protocol_attribute2):
+    """
+    A group of Protocol objects for testing limit/offest/etc.
+    """
+    protocols = []
+    site = site_client.sites(site_client.default_site)
+    for i in range(1, 6):
+        device_name = 'device{:02d}'.format(i)
+        interface_name = 'Ethernet1/{}'.format(i)
+
+        device = site.devices.post({'hostname': device_name})
+        interface = site.interfaces.post({
+            'device': device['id'],
+            'name': interface_name,
+        })
+
+        protocol = site.protocols.post({
+            'type': protocol_type['name'],
+            'device': device['id'],
+            'interface': interface['id'],
+            'attributes': {'foo': 'bar'},
+        })
+        protocols.append(protocol)
+
+    return protocols


### PR DESCRIPTION
These CLI options are standard across all resource types with their
`list` subcommands, but they were forgotten with the new Protocol and
ProtocolType objects.

Fixes #159