### PR TITLE
Update pynsot to be compatible with Click 7.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Changelog
 Version History
 ===============
 
+.. _v1.3.2:
+
+1.3.2 (2019-03-11)
+
+* Update pynsot to use Click 7.x and explicitly name subcommands with
+  underscores as such so they don't get updated to use hyphens.
+
 .. _v1.3.1:
 
 1.3.1 (2018-09-11)

--- a/pynsot/commands/cmd_networks.py
+++ b/pynsot/commands/cmd_networks.py
@@ -396,6 +396,7 @@ def siblings(ctx, *args, **kwargs):
 
 
 @list.command(
+    name='closest_parent',
     short_help='Get the closest matching parent of a network.'
 )
 @click.pass_context
@@ -454,7 +455,7 @@ def reserved(ctx, *args, **kwargs):
 
 
 # Allocation methods
-@list.command()
+@list.command(name='next_network')
 @click.option(
     '-n',
     '--num',
@@ -486,7 +487,7 @@ def next_network(ctx, *args, **kwargs):
     click.echo('\n'.join(results))
 
 
-@list.command()
+@list.command(name='next_address')
 @click.option(
     '-n',
     '--num',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click~=6.2.0
+click~=7.0.0
 PTable~=0.9.2
 netaddr~=0.7.18
 rcfile~=0.1.4


### PR DESCRIPTION
Updates pynsot to require Click 7.x now, and also updates certain subcommands with underscores in their name to explicitly use underscores.

From Click 7.0 release notes:
> Subcommands that are named by the function now automatically have the underscore replaced with a dash. If you register a function named `my_command` it becomes `my-command` in the command line interface.