### PR TITLE
[Python 3] Remove NSOT Tests from py3 and make remaining tests pass in py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
     - "2.7"
+    - "3.8"
 
 install:
     - pip install -r requirements-dev.txt

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 # Prvent import of django settings when using python 3.
 # This can be removed once NSOT supports python 3.
 import sys
+import os
 
 if sys.version_info[0] < 3:
-    DJANGO_SETTINGS_MODULE = tests.nsot_settings
+   os.environ["DJANGO_SETTINGS_MODULE"] = "tests.nsot_settings"

--- a/conftest.py
+++ b/conftest.py
@@ -4,4 +4,4 @@ import sys
 import os
 
 if sys.version_info[0] < 3:
-   os.environ["DJANGO_SETTINGS_MODULE"] = "tests.nsot_settings"
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.nsot_settings"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+# Prvent import of django settings when using python 3.
+# This can be removed once NSOT supports python 3.
+import sys
+
+if sys.version_info[0] < 3:
+    DJANGO_SETTINGS_MODULE = tests.nsot_settings

--- a/pynsot/app.py
+++ b/pynsot/app.py
@@ -8,6 +8,8 @@ way of factory methods.
 """
 
 from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
 import datetime
 import logging
 import os
@@ -20,6 +22,7 @@ from .util import get_result
 
 from .vendor import click, netaddr, prettytable
 from .vendor.slumber.exceptions import (HttpClientError, HttpServerError)
+import six
 
 
 # Constants/Globals
@@ -96,7 +99,7 @@ class NsotCLI(click.MultiCommand):
             mod = __import__('pynsot.commands.cmd_' + name,
                              None, None, ['app'])
         except ImportError as err:
-            print err
+            print(err)
             return None
         return mod.cli  # Each cmd_ plugin defines top-level "cli" command
 
@@ -164,7 +167,7 @@ class App(object):
         """
         log.debug('PRETTY DICT INCOMING DATA = %r', data)
         pretty = ''
-        for key, val in sorted(data.iteritems()):
+        for key, val in sorted(six.iteritems(data)):
             if isinstance(val, list):
                 # Sort, add a newline and indent so that nested value items
                 # look better.
@@ -814,7 +817,7 @@ class App(object):
         log.debug('PAYLOAD [in]: %r', payload)
 
         # Update the payload from the CLI params if the value isn't null.
-        for key, val in data.iteritems():
+        for key, val in six.iteritems(data):
             # If we're updating attributes, reconcile with existing attributes
             if key == 'attributes':
                 attrs = payload['attributes']

--- a/pynsot/commands/callbacks.py
+++ b/pynsot/commands/callbacks.py
@@ -4,13 +4,11 @@
 Callbacks used in handling command plugins.
 """
 from __future__ import unicode_literals
-
 import ast
 import csv
 import logging
 
 from six import string_types
-
 from ..vendor import click
 
 

--- a/pynsot/commands/callbacks.py
+++ b/pynsot/commands/callbacks.py
@@ -3,11 +3,13 @@
 """
 Callbacks used in handling command plugins.
 """
-
 from __future__ import unicode_literals
+
 import ast
 import csv
 import logging
+
+from six import string_types
 
 from ..vendor import click
 
@@ -78,7 +80,7 @@ def transform_attributes(ctx, param, value):
     log.debug('TRANSFORM_ATTRIBUTES [IN]: %r' % (value,))
 
     # If this is a simple string, make it a list.
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         value = [value]
 
     # Flatten the attributes using a set to eliminate any duplicates.
@@ -168,7 +170,7 @@ def process_bulk_add(ctx, param, value):
                 continue
 
             # Evaluate strings and if they are booleans, convert them.
-            if not isinstance(val, basestring):
+            if not isinstance(val, string_types):
                 msg = 'Error parsing file on line %d' % (lineno,)
                 raise click.BadParameter(msg)
             if val.title() in ('True', 'False'):

--- a/pynsot/commands/cmd_attributes.py
+++ b/pynsot/commands/cmd_attributes.py
@@ -13,11 +13,9 @@ fundamentally simplified to this::
     getattr(ctx.obj, ctx.info_name)(ctx.params)
 """
 from __future__ import unicode_literals
-
 import logging
 
 from six import string_types
-
 from ..vendor import click
 from . import callbacks
 

--- a/pynsot/commands/cmd_attributes.py
+++ b/pynsot/commands/cmd_attributes.py
@@ -12,9 +12,11 @@ fundamentally simplified to this::
 
     getattr(ctx.obj, ctx.info_name)(ctx.params)
 """
-
 from __future__ import unicode_literals
+
 import logging
+
+from six import string_types
 
 from ..vendor import click
 from . import callbacks
@@ -406,7 +408,7 @@ def update(ctx, allow_empty, description, display, id, multi, name, pattern,
         # it's a tuple with 1 or more item, it's been provided.
         if any([
             val in (True, False),
-            isinstance(val, basestring),
+            isinstance(val, string_types),
             (isinstance(val, tuple) and len(val) > 0)
         ]):
             provided.append(opt)
@@ -421,7 +423,7 @@ def update(ctx, allow_empty, description, display, id, multi, name, pattern,
     # them alone.
     if any([
         allow_empty is not None,
-        isinstance(pattern, basestring),
+        isinstance(pattern, string_types),
         valid_values
     ]):
         log.debug('Constraint field provided; updating constraints...')

--- a/pynsot/commands/types.py
+++ b/pynsot/commands/types.py
@@ -3,7 +3,6 @@
 """
 Custom Click parameter types.
 """
-
 from __future__ import unicode_literals
 
 from ..vendor import click
@@ -23,7 +22,7 @@ class NetworkIdParamType(click.ParamType):
         for test in tests:
             try:
                 win = test(value)
-            except:
+            except Exception:
                 pass
             else:
                 if not win:
@@ -50,7 +49,7 @@ class NaturalKeyParamType(click.ParamType):
         for test in tests:
             try:
                 win = test(value)
-            except:
+            except Exception:
                 pass
             else:
                 if not win:

--- a/pynsot/constants.py
+++ b/pynsot/constants.py
@@ -5,6 +5,7 @@ Constant values used across the project.
 """
 
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import os
 
 
@@ -45,7 +46,7 @@ OPTIONAL_FIELDS = {
 USER_HOME = os.path.expanduser('~')
 DOTFILE_NAME = '.pynsotrc'
 DOTFILE_PATH = os.path.join(USER_HOME, DOTFILE_NAME)
-DOTFILE_PERMS = 0600  # -rw-------
+DOTFILE_PERMS = 0o600  # -rw-------
 
 # Config section name
 SECTION_NAME = 'pynsot'

--- a/pynsot/dotfile.py
+++ b/pynsot/dotfile.py
@@ -5,7 +5,8 @@ Handle the read, write, and generation of the .pynsotrc config file.
 """
 
 from __future__ import unicode_literals
-from ConfigParser import RawConfigParser
+from __future__ import absolute_import
+from configparser import ConfigParser
 import copy
 import logging
 import os
@@ -13,6 +14,7 @@ import os
 from .vendor import click
 from .vendor import rcfile
 from . import constants
+import six
 
 
 __author__ = 'Jathan McCollum'
@@ -122,15 +124,15 @@ class Dotfile(object):
         """
         if filepath is None:
             filepath = self.filepath
-        config = RawConfigParser()
+        config = ConfigParser()
         section = constants.SECTION_NAME
         config.add_section(section)
 
         # Set the config settings
-        for key, val in config_data.iteritems():
+        for key, val in six.iteritems(config_data):
             config.set(section, key, val)
 
-        with open(filepath, 'wb') as dotfile:
+        with open(filepath, 'w') as dotfile:
             config.write(dotfile)
 
         self.enforce_perms()
@@ -227,7 +229,7 @@ class Dotfile(object):
         :param kwargs:
             Keyword arguments of prepared values
         """
-        for field, default_value in field_items.iteritems():
+        for field, default_value in six.iteritems(field_items):
             prompt = 'Please enter %s' % (field,)
 
             # If it's already in the config data, move on.
@@ -248,7 +250,7 @@ class Dotfile(object):
 
                 # If the default_value is a string, prompt for it, but present
                 # it as a default.
-                elif isinstance(default_value, basestring):
+                elif isinstance(default_value, six.string_types):
                     value = click.prompt(
                         prompt, type=str, default=default_value
                     )

--- a/pynsot/dotfile.py
+++ b/pynsot/dotfile.py
@@ -44,30 +44,28 @@ class Dotfile(object):
         """
         Read ``~/.pynsotrc`` and return it as a dict.
         """
-        config = ConfigParser()
-        config.read(self.filepath)
-
-        # If there is *no* config data so far and...
-        if constants.SECTION_NAME in config:
-            self.config = config[constants.SECTION_NAME]
-        elif not os.path.exists(self.filepath):
+        config = {}
+        if not os.path.exists(self.filepath):
             p = '%s not found; would you like to create it?' % (self.filepath,)
             if click.confirm(p, default=True, abort=True):
                 config_data = self.get_config_data(**kwargs)
                 self.write(config_data)  # Write config to disk
-                self.config = config_data  # Return the contents
+                config = config_data  # Return the contents
         else:
-            self.config = {}
+            parser = ConfigParser()
+            parser.read(self.filepath)
+            if constants.SECTION_NAME in parser:
+                config = parser[constants.SECTION_NAME]
 
         # If we have configuration values, validate the permissions and
         # presence of fields in the dotfile.
-        auth_method = self.config.get('auth_method')
+        auth_method = config.get('auth_method')
         if auth_method == 'auth_token':
             self.validate_perms()
             required_fields = self.get_required_fields(auth_method)
-            self.validate_fields(self.config, required_fields)
+            self.validate_fields(config, required_fields)
 
-        return self.config
+        return config
 
     def validate_perms(self):
         """Make sure dotfile ownership and permissions are correct."""

--- a/pynsot/dotfile.py
+++ b/pynsot/dotfile.py
@@ -6,7 +6,7 @@ Handle the read, write, and generation of the .pynsotrc config file.
 
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from configparser import ConfigParser
+from configparser import RawConfigParser
 import copy
 import logging
 import os
@@ -124,7 +124,7 @@ class Dotfile(object):
         """
         if filepath is None:
             filepath = self.filepath
-        config = ConfigParser()
+        config = RawConfigParser()
         section = constants.SECTION_NAME
         config.add_section(section)
 

--- a/pynsot/models.py
+++ b/pynsot/models.py
@@ -279,7 +279,7 @@ class Resource(collections.MutableMapping):
             x = '%s:%s' % (self.identifier, self._site_id)
             y = '%s:%s' % (other.identifier, other._site_id)
             return x == y
-        except:
+        except Exception:
             raise TypeError('Other object is not a Resource type')
 
     def log_error(self, error):
@@ -291,7 +291,7 @@ class Resource(collections.MutableMapping):
         if hasattr(error, 'response') and hasattr(error.response, 'json'):
             try:
                 meta = error.response.json()
-            except:
+            except Exception:
                 meta = error.response
         else:
             meta = error

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = tests.nsot_settings
 django_find_project = false
 python_paths = .
 addopts = -vv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 fake-factory~=0.5.0
-flake8~=3.3.0
+flake8~=3.7.8
 ipdb~=0.9.3
 ipython~=5.0
 nsot~=1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 click~=7.0.0
 PTable~=0.9.2
 netaddr~=0.7.18
-rcfile~=0.1.4
 requests~=2.20.0
 slumber~=0.7.1

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -5,6 +5,7 @@ Make dummy data and fixtures and stuff.
 """
 
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import logging
 import os
 

--- a/tests/nsot_settings.py
+++ b/tests/nsot_settings.py
@@ -10,9 +10,9 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 
 
-SECRET_KEY = u'fMK68NKgazLCjjTXjDtthhoRUS8IV4lwD-9G7iVd2Xs='
 from nsot.conf.settings import *  # noqa
 import os.path
+import django
 
 
 # Path where the config is found.
@@ -71,6 +71,7 @@ SERVE_STATIC_FILES = True
 # encryption/decryption of sessions and auth tokens. A unique key is randomly
 # generated for you when you utilize ``nsot-server init``
 # https://cryptography.io/en/latest/fernet/#cryptography.fernet.Fernet.generate_key
+SECRET_KEY = u'fMK68NKgazLCjjTXjDtthhoRUS8IV4lwD-9G7iVd2Xs='
 
 # Header to check for Authenticated Email. This is intended for use behind an
 # authenticating reverse proxy.
@@ -87,3 +88,8 @@ AUTH_TOKEN_EXPIRY = 600  # 10 minutes
 # under many seemingly-safe web server configurations.
 # https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ['*']
+
+# Force django setup to finish before executing tests. This is needed because we don't
+# set DJANGO_SETTINGS_MODULE in pytest.ini.
+django.setup() 
+django.setup() 

--- a/tests/nsot_settings.py
+++ b/tests/nsot_settings.py
@@ -92,4 +92,3 @@ ALLOWED_HOSTS = ['*']
 # Force django setup to finish before executing tests. This is needed because we don't
 # set DJANGO_SETTINGS_MODULE in pytest.ini.
 django.setup() 
-django.setup() 

--- a/tests/nsot_settings.py
+++ b/tests/nsot_settings.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 
 
+SECRET_KEY = u'fMK68NKgazLCjjTXjDtthhoRUS8IV4lwD-9G7iVd2Xs='
 from nsot.conf.settings import *  # noqa
 import os.path
 
@@ -70,7 +71,6 @@ SERVE_STATIC_FILES = True
 # encryption/decryption of sessions and auth tokens. A unique key is randomly
 # generated for you when you utilize ``nsot-server init``
 # https://cryptography.io/en/latest/fernet/#cryptography.fernet.Fernet.generate_key
-SECRET_KEY = u'fMK68NKgazLCjjTXjDtthhoRUS8IV4lwD-9G7iVd2Xs='
 
 # Header to check for Authenticated Email. This is intended for use behind an
 # authenticating reverse proxy.

--- a/tests/test_dotfile.py
+++ b/tests/test_dotfile.py
@@ -5,6 +5,7 @@ Test the dotfile.
 """
 
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import copy
 import logging
 import os

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@
 Test the utils lib.
 """
 
+from __future__ import absolute_import
 import pytest  # noqa
 
 from pynsot.util import slugify, validate_cidr

--- a/tests/util.py
+++ b/tests/util.py
@@ -71,7 +71,7 @@ class CliRunner(BaseCliRunner):
         cwd = os.getcwd()
         t = tempfile.mkdtemp()
         os.chdir(t)
-        rcfile = dotfile.Dotfile('.pynsotrc')
+        rcfile = dotfile.Dotfile(config_path)
         rcfile.write(self.client_config)
         try:
             yield t

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,6 +5,8 @@ Utilities for testing.
 """
 
 from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
 import collections
 import contextlib
 from itertools import islice
@@ -21,6 +23,8 @@ from pynsot.app import app
 from pynsot import client
 from pynsot import dotfile
 from pynsot.vendor.click.testing import CliRunner as BaseCliRunner
+import six
+from six.moves import range
 
 
 log = logging.getLogger(__name__)
@@ -228,7 +232,7 @@ def generate_attributes(attributes=None, as_dict=True):
         attributes = ATTRIBUTE_DATA
 
     attrs = []
-    for attr_name, attr_values in attributes.iteritems():
+    for attr_name, attr_values in six.iteritems(attributes):
         if random.choice((True, False)):
             attr_value = random.choice(attr_values)
             attrs.append(Attribute(attr_name, attr_value))
@@ -371,11 +375,11 @@ def populate_sites(site_data):
         try:
             result = api.sites.post(d)
         except Exception as err:
-            print err, d['name']
+            print(err, d['name'])
         else:
             results.append(result)
 
-    print 'Created', len(results), 'sites.'
+    print('Created', len(results), 'sites.')
 
 
 def rando_set_action():
@@ -387,5 +391,5 @@ def rando_set_query():
     """Return a random set theory query string."""
     action = rando_set_action()
     return ' '.join(
-        action + '%s=%s' % (k, v) for k, v in generate_attributes().iteritems()
+        action + '%s=%s' % (k, v) for k, v in six.iteritems(generate_attributes())
     )


### PR DESCRIPTION
In order to unblock code depending on pynsot to move to Python3, I'm focusing on getting beta python3 support in pynsot before NSOT has been fully migrated to py3. In order to do this I need to exclude the NSOT/Django-related tests from executing in pynsot in a python 3 environment. 

I'm doing this by selectively setting the DJANGO_SETTINGS_MODULE environment variable only when running in Python 2. In Python 3, this will not be set which will cause all tests relying on Django to be skipped by py.test. 

Some other modifications were made to allow the non-django tests to pass in both py2 and py3.  I also ran python-modernize on affected files.

Finally, add Python 3.8 builds to our Travis setup.