### PR TITLE
Adding configparser Python3 backport

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click~=7.0.0
+configparser~=4.0.2
 PTable~=0.9.2
 netaddr~=0.7.18
 requests~=2.20.0


### PR DESCRIPTION
For py2/py3 compatibility, ensure the python3 backport of configparser is available for python2 builds, since the 'configparser' module doesn't exist in Python 2.