### PR TITLE
Allow for /etc/pynsotrc

### DIFF
--- a/pynsot/constants.py
+++ b/pynsot/constants.py
@@ -45,7 +45,8 @@ OPTIONAL_FIELDS = {
 # Path stuff
 USER_HOME = os.path.expanduser('~')
 DOTFILE_NAME = '.pynsotrc'
-DOTFILE_PATH = os.path.join(USER_HOME, DOTFILE_NAME)
+DOTFILE_USER_PATH = os.path.join(USER_HOME, DOTFILE_NAME)
+DOTFILE_GLOBAL_PATH = '/etc/pynsotrc'
 DOTFILE_PERMS = 0o600  # -rw-------
 
 # Config section name

--- a/pynsot/dotfile.py
+++ b/pynsot/dotfile.py
@@ -45,7 +45,7 @@ class Dotfile(object):
         Read ``~/.pynsotrc`` and return it as a dict.
         """
         config = {}
-        if (not os.path.exists(self.filepath) and 
+        if (not os.path.exists(self.filepath) and
                 not os.path.exists(constants.DOTFILE_GLOBAL_PATH)):
             p = '%s not found; would you like to create it?' % (self.filepath,)
             if click.confirm(p, default=True, abort=True):

--- a/pynsot/dotfile.py
+++ b/pynsot/dotfile.py
@@ -37,7 +37,7 @@ class DotfileError(Exception):
 
 class Dotfile(object):
     """Create, read, and write a dotfile."""
-    def __init__(self, filepath=constants.DOTFILE_PATH, **kwargs):
+    def __init__(self, filepath=constants.DOTFILE_USER_PATH, **kwargs):
         self.filepath = filepath
 
     def read(self, **kwargs):
@@ -45,7 +45,8 @@ class Dotfile(object):
         Read ``~/.pynsotrc`` and return it as a dict.
         """
         config = {}
-        if not os.path.exists(self.filepath):
+        if (not os.path.exists(self.filepath) and 
+                not os.path.exists(constants.DOTFILE_GLOBAL_PATH)):
             p = '%s not found; would you like to create it?' % (self.filepath,)
             if click.confirm(p, default=True, abort=True):
                 config_data = self.get_config_data(**kwargs)
@@ -53,7 +54,11 @@ class Dotfile(object):
                 config = config_data  # Return the contents
         else:
             parser = ConfigParser()
-            parser.read(self.filepath)
+            if os.path.exists(constants.DOTFILE_GLOBAL_PATH):
+                parser.read(constants.DOTFILE_GLOBAL_PATH)
+            if os.path.exists(self.filepath):
+                # these settings will override any settings from global file
+                parser.read(self.filepath)
             if constants.SECTION_NAME in parser:
                 config = parser[constants.SECTION_NAME]
 


### PR DESCRIPTION
#170 replaced the rcfile lib with configparser, but this had a side-effect of removing support for pynsotrc files anywhere other than ~/.pynsotrc. Given that we want to allow a global config in /etc/pynsotrc as well as a local one in USER_HOME, this may break existing deployments. 

This PR adds back the ability to read from a global /etc/pynsotrc file and keeps us consistent with our documentation (https://pynsot.readthedocs.io/en/latest/config.html#configuration-basics). 

Note: There still may be other .pynsotrc locations that rcfile would automatically read from that don't work anymore, however we don't plan to support those locations. Please ensure your config file is in one of these two supported locations.